### PR TITLE
fix: missing queryset in TokenViewBase viewset

### DIFF
--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -11,6 +11,7 @@ class TokenViewBase(generics.GenericAPIView):
     authentication_classes = ()
 
     serializer_class = None
+    queryset = ''
 
     www_authenticate_realm = 'api'
 


### PR DESCRIPTION
### Fix missing queryset

This fix include a default **queryset** for **TokenViewBase** in order to avoid server error in DRF Web browsable API:

_Error screenshot:_

![Screenshot from 2019-11-12 00-09-23](https://user-images.githubusercontent.com/35640157/68649866-f2bed700-04e0-11ea-8553-9633315ee34b.png)
