### PR TITLE
Add "iat" claim to token

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -113,6 +113,7 @@ class TokenRefreshSerializer(serializers.Serializer):
 
             refresh.set_jti()
             refresh.set_exp()
+            refresh.set_iat()
 
             data['refresh'] = str(refresh)
 
@@ -129,8 +130,9 @@ class TokenRefreshSlidingSerializer(serializers.Serializer):
         # passed
         token.check_exp(api_settings.SLIDING_TOKEN_REFRESH_EXP_CLAIM)
 
-        # Update the "exp" claim
+        # Update the "exp" and "iat" claims
         token.set_exp()
+        token.set_iat()
 
         return {'token': str(token)}
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -49,8 +49,9 @@ class Token:
             # New token.  Skip all the verification steps.
             self.payload = {api_settings.TOKEN_TYPE_CLAIM: self.token_type}
 
-            # Set "exp" claim with default value
+            # Set "exp" and "iat" claims with default value
             self.set_exp(from_time=self.current_time, lifetime=self.lifetime)
+            self.set_iat(at_time=self.current_time)
 
             # Set "jti" claim
             self.set_jti()
@@ -125,6 +126,9 @@ class Token:
     def set_exp(self, claim='exp', from_time=None, lifetime=None):
         """
         Updates the expiration time of a token.
+
+        See here:
+        https://tools.ietf.org/html/rfc7519#section-4.1.4
         """
         if from_time is None:
             from_time = self.current_time
@@ -133,6 +137,18 @@ class Token:
             lifetime = self.lifetime
 
         self.payload[claim] = datetime_to_epoch(from_time + lifetime)
+
+    def set_iat(self, claim='iat', at_time=None):
+        """
+        Updates the time at which the token was issued.
+
+        See here:
+        https://tools.ietf.org/html/rfc7519#section-4.1.6
+        """
+        if at_time is None:
+            at_time = self.current_time
+
+        self.payload[claim] = datetime_to_epoch(at_time)
 
     def check_exp(self, claim='exp', current_time=None):
         """

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -57,8 +57,9 @@ class TestToken(TestCase):
         self.assertEqual(t.current_time, now)
         self.assertIsNone(t.token)
 
-        self.assertEqual(len(t.payload), 3)
-        self.assertEqual(t.payload['exp'], datetime_to_epoch(now + MyToken.lifetime))
+        self.assertEqual(len(t.payload), 4)
+        self.assertEqual(t.payload['exp'], datetime_to_epoch(now + MyToken.lifetime)) 
+        self.assertEqual(t.payload['iat'], datetime_to_epoch(now))
         self.assertIn('jti', t.payload)
         self.assertEqual(t.payload[api_settings.TOKEN_TYPE_CLAIM], MyToken.token_type)
 
@@ -85,9 +86,10 @@ class TestToken(TestCase):
         self.assertEqual(t.current_time, now)
         self.assertEqual(t.token, encoded_good_token)
 
-        self.assertEqual(len(t.payload), 4)
+        self.assertEqual(len(t.payload), 5)
         self.assertEqual(t['some_value'], 'arst')
         self.assertEqual(t['exp'], datetime_to_epoch(original_now + MyToken.lifetime))
+        self.assertEqual(t['iat'], datetime_to_epoch(original_now))
         self.assertEqual(t[api_settings.TOKEN_TYPE_CLAIM], MyToken.token_type)
         self.assertIn('jti', t.payload)
 
@@ -166,6 +168,7 @@ class TestToken(TestCase):
         # content.
         del token[api_settings.TOKEN_TYPE_CLAIM]
         del token['jti']
+        del token['iat']
 
         # Should encode the given token
         encoded_token = str(token)
@@ -232,6 +235,21 @@ class TestToken(TestCase):
         token.set_exp(claim='refresh_exp', from_time=now, lifetime=timedelta(days=1))
         self.assertIn('refresh_exp', token)
         self.assertEqual(token['refresh_exp'], datetime_to_epoch(now + timedelta(days=1)))
+
+    def test_set_iat(self):
+        now = make_utc(datetime(year=2000, month=1, day=1))
+
+        token = MyToken()
+        token.current_time = now
+
+        # By default, should add 'iat' claim to token using `self.current_time`
+        token.set_iat()
+        self.assertEqual(token['iat'], datetime_to_epoch(now))
+
+        # Should allow overriding of time and claim name
+        token.set_iat(claim='refresh_iat', at_time=now + timedelta(days=1))
+        self.assertIn('refresh_iat', token)
+        self.assertEqual(token['refresh_iat'], datetime_to_epoch(now + timedelta(days=1)))
 
     def test_check_exp(self):
         token = MyToken()


### PR DESCRIPTION
This is a proper extension of https://github.com/davesque/django-rest-framework-simplejwt/pull/45.

Set "iat" by default to issued tokens.

I was also looking into letting user configure whether they want to include the additional field or not, but that requires a little bit of monkey-patching in tests, and I think it just adds unnecessary complexity.

Let me know what are your thoughts on this and whether it could benefit from improvement.