### PR TITLE
Fix documentation error caused by wrong use of serializer on TokenRefreshSerializer

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -94,6 +94,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
 
 class TokenRefreshSerializer(serializers.Serializer):
     refresh = serializers.CharField()
+    access = serializers.ReadOnlyField()
 
     def validate(self, attrs):
         refresh = RefreshToken(attrs['refresh'])


### PR DESCRIPTION
1. There's no `access` field in `TokenRefreshSerializer`, which **actually exists in the response.**
2. It is added through the `validate` method.
3. If you use [drf-yasg](https://github.com/axnsan12/drf-yasg), which generates the swagger documents based on drf's serializer, it detects it that there's no such `access` field.
4. It made our team to be confused for several times.
5. This PR resolves that documentation error, with the better readability.

Before:
![Imgur](https://i.imgur.com/3aUyXAm.png)
After:
![Imgur](https://i.imgur.com/myEWpkj.png)

