### PR TITLE
Update repo URL [ci skip]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           user: jazzband
           password: ${{ secrets.JAZZBAND_RELEASE_KEY }}
-          repository_url: https://jazzband.co/projects/django-rest-framework-simplejwt/upload
+          repository_url: https://jazzband.co/projects/djangorestframework-simplejwt/upload


### PR DESCRIPTION
@jezdez Does this URL also need to be fixed in the release workflow? Ref the release mechanism failed again in https://github.com/jazzband/djangorestframework-simplejwt/actions/runs/857825539.

I also still can't merge PRs on my own nor commit them. That might be a branch protection rule.