### PR TITLE
Fix default_app_config deprecation

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/__init__.py
+++ b/rest_framework_simplejwt/token_blacklist/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'rest_framework_simplejwt.token_blacklist.apps.TokenBlacklistConfig'
+from django import VERSION
+
+if VERSION < (3, 2):
+    default_app_config = 'rest_framework_simplejwt.token_blacklist.apps.TokenBlacklistConfig'


### PR DESCRIPTION
Django 3.2 automatically detects AppConfig and therefore this setting is no longer required.

https://docs.djangoproject.com/en/dev/releases/3.2/#automatic-appconfig-discovery