### PR TITLE
Tokens in cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
+jwttest/
+manage.py
+
 # Flask stuff:
 instance/
 .webassets-cache

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -41,6 +41,10 @@ Some of Simple JWT's behavior can be customized through settings variables in
       'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
       'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
       'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
+
+      'TOKEN_COOKIE_PATH': '/',
+      'TOKEN_COOKIE_DOMAIN': None,
+      'TOKEN_COOKIE_SAMESITE': None,
   }
 
 Above, the default values for these settings are shown.
@@ -236,3 +240,24 @@ More about this in the "Sliding tokens" section below.
 
 The claim name that is used to store the expiration time of a sliding token's
 refresh period.  More about this in the "Sliding tokens" section below.
+
+``TOKEN_COOKIE_PATH``
+-----------------------------------
+
+The value for the ``Path`` attribute of the token carrying cookie. Defaults to ``'/'``.
+
+``TOKEN_COOKIE_DOMAIN``
+-----------------------------------
+
+The value for the ``Domain`` attribute of the token carrying cookie. Defaults to ``None``.
+
+``TOKEN_COOKIE_SAMESITE``
+-----------------------------------
+
+The value for the ``SameSite`` attribute of the token carrying cookie. Defaults to ``'Lax'``.
+
+``TOKEN_COOKIE_SECURE``
+-----------------------------------
+
+The value for the ``Secure` attribute of the token carrying cookie. Defaults to ``False``.
+

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -37,6 +37,11 @@ DEFAULTS = {
     'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
     'SLIDING_TOKEN_LIFETIME': timedelta(minutes=5),
     'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
+
+    'TOKEN_COOKIE_PATH': '/',
+    'TOKEN_COOKIE_DOMAIN': None,
+    'TOKEN_COOKIE_SAMESITE': 'Lax',
+    'TOKEN_COOKIE_SECURE': False,
 }
 
 IMPORT_STRINGS = (

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -4,6 +4,9 @@ from rest_framework.response import Response
 from . import serializers
 from .authentication import AUTH_HEADER_TYPES
 from .exceptions import InvalidToken, TokenError
+from .settings import api_settings
+from .tokens import RefreshToken, UntypedToken
+from .utils import datetime_from_epoch
 
 
 class TokenViewBase(generics.GenericAPIView):
@@ -84,3 +87,119 @@ class TokenVerifyView(TokenViewBase):
 
 
 token_verify = TokenVerifyView.as_view()
+
+
+##
+## Views for cookie based token (only refresh token in cookie)
+##
+
+class TokenCookieBaseView(generics.GenericAPIView):
+    permission_classes = ()
+    authentication_classes = ()
+
+    serializer_class = None
+
+    www_authenticate_realm = 'api'
+
+    def get_authenticate_header(self, request):
+        return '{0} realm="{1}"'.format(
+            AUTH_HEADER_TYPES[0],
+            self.www_authenticate_realm,
+        )
+
+
+class TokenPairCookieBaseView(TokenCookieBaseView):
+    def use_serializer(self, serializer):
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError as e:
+            raise InvalidToken(e.args[0])
+        
+        validated_data = serializer.validated_data
+        
+        if 'refresh' in validated_data:
+            refresh_token = RefreshToken(validated_data.pop('refresh'))
+        else:
+            refresh_token = None
+
+        response = Response(validated_data, status=status.HTTP_200_OK)
+
+        if not refresh_token == None:
+            response.set_cookie(
+                key = 'refresh',
+                value = str(refresh_token),
+                expires = datetime_from_epoch(refresh_token.payload['exp']),
+                path = api_settings.TOKEN_COOKIE_PATH,
+                domain = api_settings.TOKEN_COOKIE_DOMAIN,
+                samesite = api_settings.TOKEN_COOKIE_SAMESITE,
+                secure = api_settings.TOKEN_COOKIE_SECURE,
+                httponly = True
+                )
+        
+        return response
+
+
+class TokenObtainPairCookieView(TokenPairCookieBaseView):
+    """
+    Takes a set of user credentials and returns an access and refresh JSON web
+    token pair to prove the authentication of those credentials.
+
+    Refresh token is sent via httponly cookie. This view needs CSRF protection.
+    """
+
+    serializer_class = serializers.TokenObtainPairSerializer
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data = request.data)
+
+        return self.use_serializer(serializer)
+
+
+token_obtain_pair_cookie = TokenObtainPairCookieView.as_view()
+
+
+class TokenRefreshCookieView(TokenPairCookieBaseView):
+    """
+    Takes a refresh type JSON web token and returns an access type JSON web
+    token if the refresh token is valid.
+
+    If refresh token is rotated, it is sent via httponly cookie. This view needs CSRF protection.
+    """
+    serializer_class = serializers.TokenRefreshSerializer
+
+    def post(self, request, *args, **kwargs):
+        try:
+            refresh = request.COOKIES['refresh']
+        except KeyError:
+            refresh = ''
+        
+        serializer = self.get_serializer(data = {'refresh': refresh})
+
+        return self.use_serializer(serializer)
+
+
+token_refresh_cookie = TokenRefreshCookieView.as_view()
+
+
+class TokenVerifyCookieView(TokenCookieBaseView):
+    """
+    Takes a token residing in a cookie and indicates if it is valid.  This view provides no
+    information about a token's fitness for a particular use.
+    """
+    def post(self, request, *args, **kwargs):
+        try:
+            refresh = request.COOKIES['refresh']
+        except KeyError:
+            refresh = ''
+
+        serializer = serializers.TokenVerifySerializer(data = {'token': refresh})
+
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError as e:
+            raise InvalidToken(e.args[0])
+        
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)
+
+
+token_verify_cookie = TokenVerifyCookieView.as_view()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -403,7 +403,7 @@ class TestTokenRefreshCookieView(TestTokenRefreshView):
         self.assertEqual(access['exp'], datetime_to_epoch(now + api_settings.ACCESS_TOKEN_LIFETIME))
 
 
-class TestTokenVerifyView(TestTokenVerifyView):
+class TestTokenVerifyCookieView(TestTokenVerifyView):
     view_name = 'token_verify_cookie'
 
     def test_it_should_return_401_if_token_invalid(self):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -14,4 +14,9 @@ urlpatterns = [
     re_path(r'^token/verify/$', jwt_views.token_verify, name='token_verify'),
 
     re_path(r'^test-view/$', views.test_view, name='test_view'),
+
+    re_path(r'^api/cookietoken/pair/$', jwt_views.token_obtain_pair_cookie, name='token_obtain_pair_cookie'),
+    re_path(r'^api/cookie/cookietoken/refresh/$', jwt_views.token_refresh_cookie, name='token_refresh_cookie'),
+
+    re_path(r'^api/cookie/cookietoken/verify/$', jwt_views.token_verify_cookie, name='token_verify_cookie'),
 ]


### PR DESCRIPTION
### Issues:
There is a problem of storing ***refresh token*** at client side between page reloads and browser restarts. Localstorage or Sessionstorage are bad idea for such secret data due to a chance of XSS attack leaking the refresh token.

### Solution proposed:
A possible solution would be to put the refresh token in ***httponly*** cookie and set its **path** to certain urls responsible for refreshing access token or verifying the token inside that cookie. Though one has to implement ***CSRF protection*** for these paths only.

### What is implemented?
New views are implemented as follows:
- One view will authenticate the user with credentials and send the refresh token in an httponly cookie. The access token will be sent inside the response body.
- Another view will refresh the access token by accessing the refresh token from the cookie.
- A new verifier view for the tokens residing in cookies.

Corresponding tests are implemented too.

New settings are added for specifying the -
- Path
- Domain
- SameSite and
- Secure

attributes of the refresh cookie token.
