### PR TITLE
Make clear that need to add simple_jwt to installed apps

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,11 +22,17 @@ Simple JWT can be installed with pip::
   pip install djangorestframework-simplejwt
 
 Then, your django project must be configured to use the library.  In
-``settings.py``, add
+``settings.py``, add ``rest_framework_simplejwt`` to the list of apps and
 ``rest_framework_simplejwt.authentication.JWTAuthentication`` to the list of
 authentication classes:
 
 .. code-block:: python
+
+  INSTALLED_APPS = [
+      ...
+      'rest_framework_simplejwt',
+      ...
+  ]
 
   REST_FRAMEWORK = {
       ...

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -22,17 +22,11 @@ Simple JWT can be installed with pip::
   pip install djangorestframework-simplejwt
 
 Then, your django project must be configured to use the library.  In
-``settings.py``, add ``rest_framework_simplejwt`` to the list of apps and
+``settings.py``, add
 ``rest_framework_simplejwt.authentication.JWTAuthentication`` to the list of
 authentication classes:
 
 .. code-block:: python
-
-  INSTALLED_APPS = [
-      ...
-      'rest_framework_simplejwt',
-      ...
-  ]
 
   REST_FRAMEWORK = {
       ...
@@ -71,6 +65,18 @@ signing key:
       path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
       ...
   ]
+
+If you wish to use localizations/translations you simple needs to add 
+``rest_framework_simplejwt`` to ``INSTALLED_APPS``.
+
+.. code-block:: python
+
+  INSTALLED_APPS = [
+      ...
+      'rest_framework_simplejwt',
+      ...
+  ]
+
 
 Usage
 -----

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -66,7 +66,7 @@ signing key:
       ...
   ]
 
-If you wish to use localizations/translations you simple needs to add 
+If you wish to use localizations/translations, simply add 
 ``rest_framework_simplejwt`` to ``INSTALLED_APPS``.
 
 .. code-block:: python


### PR DESCRIPTION
Just added on the documentation the necessity of adding `rest_framework_simplejwt` to `INSTALLED_APPS`

#419 

