### PR TITLE
Adding media_type in JWTAuthentication 

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -22,6 +22,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
     token provided in a request header.
     """
     www_authenticate_realm = 'api'
+    media_type = 'application/json'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
The drf render BrowsableAPIRenderer is requiring 
a media_type object when generating a generic form
that includes a content type field, error will occur
if JWTAuthentication class does't have media_type.