### PR TITLE
Avoid blacklisting app migrations failing in projects with multiple databases

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/migrations/0003_auto_20171017_2007.py
+++ b/rest_framework_simplejwt/token_blacklist/migrations/0003_auto_20171017_2007.py
@@ -6,7 +6,8 @@ from django.db import migrations
 def populate_jti_hex(apps, schema_editor):
     OutstandingToken = apps.get_model('token_blacklist', 'OutstandingToken')
 
-    for token in OutstandingToken.objects.all():
+    db_alias = schema_editor.connection.alias
+    for token in OutstandingToken.objects.using(db_alias).all():
         token.jti_hex = token.jti.hex
         token.save()
 
@@ -14,7 +15,8 @@ def populate_jti_hex(apps, schema_editor):
 def reverse_populate_jti_hex(apps, schema_editor):  # pragma: no cover
     OutstandingToken = apps.get_model('token_blacklist', 'OutstandingToken')
 
-    for token in OutstandingToken.objects.all():
+    db_alias = schema_editor.connection.alias
+    for token in OutstandingToken.objects.using(db_alias).all():
         token.jti = UUID(hex=token.jti_hex)
         token.save()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,10 @@ def pytest_configure():
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': ':memory:'
+            },
+            'other': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': 'other'
             }
         },
         SITE_ID=1,


### PR DESCRIPTION
Fixes #428 

For tests, it didn't seem straight forward to update the relevant test `tests.test_token_blacklist.TestPopulateJtiHexMigration.test_jti_field_should_contain_uuid_hex_strings` given that all querysets are run against the default database (specifically the creation of the `OutstandingToken` under `RefreshToken.for_user`). So, the best way I found to test this change is to add a second test database. Before the fix, all existing tests fail because the migration of the second database fails. After the fix, all the tests pass.