### PR TITLE
Use import_string for token_backend (Fixes #434)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## Version 4.7.3
+
+* Add integration instructions for drf-yasg ([#145](https://github.com/jazzband/djangorestframework-simplejwt/pull/145))
+* Verify Serializer Should Honour Blacklist ([#239](https://github.com/jazzband/djangorestframework-simplejwt/pull/239))
+* Added missing import in getting_started docs ([#431](https://github.com/jazzband/djangorestframework-simplejwt/pull/431))
+* Use import_string for token_backend ([#435](https://github.com/jazzband/djangorestframework-simplejwt/pull/435))
+
 ## Version 4.7.2
 
 * Fix BrowsableAPIRenderer needing `media_type` ([#426](https://github.com/jazzband/django-rest-framework-simplejwt/pull/426))

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -169,7 +169,7 @@ class Token:
     _token_backend = None
     
     def get_token_backend(self):
-        if self._token_backend = None:
+        if self._token_backend is None:
             self._token_backend = import_string(
                 "rest_framework_simplejwt.state.token_backend"
             )

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from django.utils.module_loading import import_string
 
 from .exceptions import TokenBackendError, TokenError
 from .settings import api_settings
@@ -164,10 +165,15 @@ class Token:
         token[api_settings.USER_ID_CLAIM] = user_id
 
         return token
-
+    
+    _token_backend = None
+    
     def get_token_backend(self):
-        from .state import token_backend
-        return token_backend
+        if self._token_backend = None:
+            self._token_backend = import_string(
+                "rest_framework_simplejwt.state.token_backend"
+            )
+        return self._token_backend
 
 
 class BlacklistMixin:


### PR DESCRIPTION
Fixes #434 hopefully @dabljues
 
Please let me know if this resolves your issue. You can test this by doing `pip install git+https://github.com/jazzband/djangorestframework-simplejwt.git@token-backend`

Do not merge immediately. There are performance improvements that we can possibly make here such as initially setting this in the settings rather than using state.py