### PR TITLE
Repair generation of OpenAPI with Spectacular

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -98,7 +98,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
 
 class TokenRefreshSerializer(serializers.Serializer):
     refresh = serializers.CharField()
-    access = serializers.ReadOnlyField()
+    access = serializers.CharField(read_only=True)
 
     def validate(self, attrs):
         refresh = RefreshToken(attrs['refresh'])


### PR DESCRIPTION
Tested API generation with [drf-spectacular](https://github.com/tfranzel/drf-spectacular) and [drf-yasg](https://github.com/axnsan12/drf-yasg) Both worked.
