### PR TITLE
Consider leeway when checking expiry

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -184,12 +184,17 @@ class Token:
 
     _token_backend = None
 
-    def get_token_backend(self):
+    @property
+    def token_backend(self):
         if self._token_backend is None:
             self._token_backend = import_string(
                 "rest_framework_simplejwt.state.token_backend"
             )
         return self._token_backend
+
+    def get_token_backend(self):
+        # Backward compatibility.
+        return self.token_backend
 
 
 class BlacklistMixin:

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -163,7 +163,8 @@ class Token:
             raise TokenError(format_lazy(_("Token has no '{}' claim"), claim))
 
         claim_time = datetime_from_epoch(claim_value)
-        if claim_time <= current_time:
+        leeway = self.get_token_backend().leeway
+        if claim_time <= current_time - timedelta(seconds=leeway):
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -309,6 +309,11 @@ class TestToken(TestCase):
                 "refresh_exp", current_time=current_time + timedelta(days=2)
             )
 
+        # a token 1 day expired is valid if leeway is 2 days
+        token._token_backend.leeway = timedelta(days=2).total_seconds()
+        token.check_exp('refresh_exp', current_time=current_time + timedelta(days=1))
+        token._token_backend.leeway = 0
+
     def test_for_user(self):
         username = "test_user"
         user = User.objects.create_user(

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -319,9 +319,9 @@ class TestToken(TestCase):
             token.check_exp("refresh_exp", current_time=datetime_in_leeway)
 
         # a token 1 day expired is valid if leeway is 2 days
-        token.get_token_backend().leeway = timedelta(days=2).total_seconds()
+        token.token_backend.leeway = timedelta(days=2).total_seconds()
         token.check_exp("refresh_exp", current_time=datetime_in_leeway)
-        token.get_token_backend().leeway = 0
+        token.token_backend.leeway = 0
 
     def test_for_user(self):
         username = "test_user"

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -309,10 +309,19 @@ class TestToken(TestCase):
                 "refresh_exp", current_time=current_time + timedelta(days=2)
             )
 
+    def test_check_token_not_expired_if_in_leeway(self):
+        token = MyToken()
+        token.set_exp('refresh_exp', lifetime=timedelta(days=1))
+
+        datetime_in_leeway = token.current_time + timedelta(days=1)
+
+        with self.assertRaises(TokenError):
+            token.check_exp('refresh_exp', current_time=datetime_in_leeway)
+
         # a token 1 day expired is valid if leeway is 2 days
-        token._token_backend.leeway = timedelta(days=2).total_seconds()
-        token.check_exp('refresh_exp', current_time=current_time + timedelta(days=1))
-        token._token_backend.leeway = 0
+        token.get_token_backend().leeway = timedelta(days=2).total_seconds()
+        token.check_exp('refresh_exp', current_time=datetime_in_leeway)
+        token.get_token_backend().leeway = 0
 
     def test_for_user(self):
         username = "test_user"

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -311,16 +311,16 @@ class TestToken(TestCase):
 
     def test_check_token_not_expired_if_in_leeway(self):
         token = MyToken()
-        token.set_exp('refresh_exp', lifetime=timedelta(days=1))
+        token.set_exp("refresh_exp", lifetime=timedelta(days=1))
 
         datetime_in_leeway = token.current_time + timedelta(days=1)
 
         with self.assertRaises(TokenError):
-            token.check_exp('refresh_exp', current_time=datetime_in_leeway)
+            token.check_exp("refresh_exp", current_time=datetime_in_leeway)
 
         # a token 1 day expired is valid if leeway is 2 days
         token.get_token_backend().leeway = timedelta(days=2).total_seconds()
-        token.check_exp('refresh_exp', current_time=datetime_in_leeway)
+        token.check_exp("refresh_exp", current_time=datetime_in_leeway)
         token.get_token_backend().leeway = 0
 
     def test_for_user(self):


### PR DESCRIPTION
This check usually also occurs in the TokenBackend where leeway is
already considered and we have to do the same in the check here.

Fixes #454