### PR TITLE
[Update] Allowing all algorithms PyJWT supports.

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -5,14 +5,7 @@ from jwt import InvalidAlgorithmError, InvalidTokenError, PyJWKClient, algorithm
 from .exceptions import TokenBackendError
 from .utils import format_lazy
 
-ALLOWED_ALGORITHMS = (
-    'HS256',
-    'HS384',
-    'HS512',
-    'RS256',
-    'RS384',
-    'RS512',
-)
+ALLOWED_ALGORITHMS = algorithms.get_default_algorithms().keys()
 
 
 class TokenBackend:


### PR DESCRIPTION
Allowing all algorithms like "ES256", "ES384", "ES512" and etc that PyJWT supports by setting `ALLOWED_ALGORITHMS` with "PyJWT" library's `get_default_algorithms()`.