### PR TITLE
Remove verify from jwt.decode() to follow PyJWT v2.2.0.

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -91,7 +91,6 @@ class TokenBackend:
                 token,
                 self.get_verifying_key(token),
                 algorithms=[self.algorithm],
-                verify=verify,
                 audience=self.audience,
                 issuer=self.issuer,
                 leeway=self.leeway,


### PR DESCRIPTION
According to the setup.py, simplejwt supports PyJWT v2.0.0 or later.

https://github.com/jazzband/djangorestframework-simplejwt/blob/7759aa810942863fa1c3885b7bbc2d3125e5166d/setup.py#L59

In this case, you can simply remove meaningless `verify` argument from `jwt.decode()` to support PyJWT v2.2.0.

Closes #467