### PR TITLE
Set up .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+python:
+  version: 3.8

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,19 @@
-python:
-  version: 3.8
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+   - pdf


### PR DESCRIPTION
Fixes #484

Docs failed to build perhaps due to Python 3.8 usage of walrus operator.