### PR TITLE
Add automated tests for Django 4.0 and DRF 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ jobs:
         drf-version: ['3.10', '3.11', '3.12', '3.13']
         exclude:
           - python-version: '3.7'
-            django-version: ['4.0', 'main']
+            django-version: 'main'
+          - python-version: '3.7'
+            django-version: '4.0'
           - python-version: '3.8'
             django-version: 'main'
           - django-version: '3.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         drf-version: ['3.10', '3.11', '3.12', '3.13']
         exclude:
           - python-version: '3.7'
-            django-version: 'main'
+            django-version: ['4.0', 'main']
           - python-version: '3.8'
             django-version: 'main'
           - django-version: '3.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,19 +18,6 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
         drf-version: ['3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - python-version: '3.7'
-            django-version: 'main'
-          - python-version: '3.7'
-            django-version: '4.0'
-          - python-version: '3.8'
-            django-version: 'main'
-          - django-version: '3.1'
-            drf-version: '3.10'
-          - python-version: '3.10'
-            django-version: '2.2'
-          - python-version: '3.10'
-            django-version: '3.1'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2', 'main']
-        drf-version: ['3.10', '3.11', '3.12']
+        django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
+        drf-version: ['3.10', '3.11', '3.12', '3.13']
         exclude:
           - python-version: '3.7'
             django-version: 'main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
+        django-version: ['2.2', '3.2', '4.0', 'main']
         drf-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add support for Django 4.0 + DRF 3.13 and drop Django 3.1 ([#500](https://github.com/jazzband/djangorestframework-simplejwt/pull/500))
+
 ## Version 5.0.0
 
 #### Breaking

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,8 +7,8 @@ Requirements
 ------------
 
 * Python (3.7, 3.8, 3.9, 3.10)
-* Django (2.2, 3.1, 3.2)
-* Django REST Framework (3.10, 3.11, 3.12)
+* Django (2.2, 3.2, 4.0)
+* Django REST Framework (3.10, 3.11, 3.12, 3.13)
 
 These are the officially supported python and package versions.  Other versions
 will probably work.  You're free to modify the tox config and see what is

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist=
-    py{37,38,39}-dj22-drf310-tests
-    py{37,38,39}-dj{22,31}-drf{311,312}-tests
+    py{37,38,39}-dj22-drf{310,311,312}-tests
     py{37,38,39,310}-dj32-drf{311,312,313}-tests
     py{38,39,310}-dj{40,main}-drf{311,312,313}-tests
     docs
@@ -16,8 +15,6 @@ python=
 [gh-actions:env]
 DJANGO=
     2.2: dj22
-    3.0: dj30
-    3.1: dj31
     3.2: dj32
     4.0: dj40
     main: djmain
@@ -37,7 +34,6 @@ setenv=
     PYTHONDONTWRITEBYTECODE=1
 deps=
     dj22: Django>=2.2,<2.3
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj40: pytz

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{37,38,39}-dj22-drf310-tests
     py{37,38,39}-dj{22,31}-drf{311,312}-tests
-    py{37,38,39,310}-dj32-drf{311,312}-tests
+    py{37,38,39,310}-dj{32,40}-drf{311,312,313}-tests
     py{38,39,310}-djmain-drf312-tests
     docs
 
@@ -19,11 +19,13 @@ DJANGO=
     3.0: dj30
     3.1: dj31
     3.2: dj32
+    4.0: dj40
     main: djmain
 DRF=
     3.10: drf310
     3.11: drf311
     3.12: drf312
+    3.13: drf313
 
 [testenv]
 usedevelop=True
@@ -37,9 +39,11 @@ deps=
     dj22: Django>=2.2,<2.3
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
     djmain: https://github.com/django/django/archive/main.tar.gz
     djmain: pytz
 allowlist_externals=make

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist=
     py{37,38,39}-dj22-drf310-tests
     py{37,38,39}-dj{22,31}-drf{311,312}-tests
-    py{37,38,39,310}-dj{32,40}-drf{311,312,313}-tests
-    py{38,39,310}-djmain-drf312-tests
+    py{37,38,39,310}-dj32-drf{311,312,313}-tests
+    py{38,39,310}-dj{40,main}-drf{311,312,313}-tests
     docs
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ deps=
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
+    dj40: pytz
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13


### PR DESCRIPTION
I wanted to make sure this module is working with latest Django and DRF releases so I added these versions to the configs.

Tell me if I'm wrong but I think that it adds no benefit to exclude untested version's combinations from the matrix in the test github workflow.

I made less but similar changes than in #495 (saw it afterwards sorry).