### PR TITLE
Fix RTD config to install setup.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,10 +5,12 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
+
+python:
+  install:
+  # Install dependencies from setup.py .
+    - method: setuptools
+      path: .
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
fixes #484 

```python
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-rest-framework-simplejwt/envs/latest/lib/python3.9/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-rest-framework-simplejwt/envs/latest/lib/python3.9/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-rest-framework-simplejwt/checkouts/latest/docs/conf.py", line 50, in <module>
    django_configure()
  File "/home/docs/checkouts/readthedocs.org/user_builds/django-rest-framework-simplejwt/checkouts/latest/docs/conf.py", line 25, in django_configure
    from django.conf import settings
ModuleNotFoundError: No module named 'django'
```
build failed because a required dependency was not installed

added missing python installation settings to `.readthedocs.yml` file.