### PR TITLE
Fix token blacklist enable switch for TokenVerifySerializer

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -150,10 +150,7 @@ class TokenVerifySerializer(serializers.Serializer):
     def validate(self, attrs):
         token = UntypedToken(attrs["token"])
 
-        if (
-            api_settings.BLACKLIST_AFTER_ROTATION
-            and "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS
-        ):
+        if "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS:
             jti = token.get(api_settings.JTI_CLAIM)
             if BlacklistedToken.objects.filter(token__jti=jti).exists():
                 raise ValidationError("Token is blacklisted")


### PR DESCRIPTION
BLACKLIST_AFTER_ROTATION isn't what decides whether token blacklisting is
enabled, having rest_framework_simplejwt.token_blacklist in INSTALLED_APPS
is.