### PR TITLE
If the blacklist app is enabled mark rotated refresh tokens as outstanding

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -123,6 +123,9 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_exp()
             refresh.set_iat()
 
+            if "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS:
+                refresh.create_outstanding_token()
+
             data["refresh"] = str(refresh)
 
         return data

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -44,7 +44,6 @@ class SerializerTestCase(TestCase):
 
 
 class TestTokenObtainSerializer(SerializerTestCase):
-
     def test_it_should_not_validate_if_any_fields_missing(self):
         s = TokenObtainSerializer(data={})
         self.assertFalse(s.is_valid())
@@ -96,7 +95,6 @@ class TestTokenObtainSerializer(SerializerTestCase):
 
 
 class TestTokenObtainSlidingSerializer(SerializerTestCase):
-
     def test_it_should_produce_a_json_web_token_when_valid(self):
         s = TokenObtainSlidingSerializer(
             context=MagicMock(),
@@ -116,7 +114,6 @@ class TestTokenObtainSlidingSerializer(SerializerTestCase):
 
 
 class TestTokenObtainPairSerializer(SerializerTestCase):
-
     def test_it_should_produce_a_json_web_token_when_valid(self):
         s = TokenObtainPairSerializer(
             context=MagicMock(),
@@ -221,7 +218,6 @@ class TestTokenRefreshSlidingSerializer(TestCase):
 
 
 class TestTokenRefreshSerializer(SerializerTestCase):
-
     def test_it_should_raise_token_error_if_token_invalid(self):
         token = RefreshToken()
         del token["exp"]


### PR DESCRIPTION
The token blacklisting itself works without this (the OutstandingToken
object will be created when adding a token to the blacklist), but the list
of outstanding tokens would very quickly get out of date in the presence of
refresh token rotation, and be unusable for any other purpose (for example
being able to tell which users have valid outstanding tokens).

Fixes #363 and #25