### PR TITLE
Maintain compatibility with serializer_class overrides

### DIFF
--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -13,11 +13,17 @@ class TokenViewBase(generics.GenericAPIView):
     authentication_classes = ()
 
     serializer_class = None
+    _serializer_class = ""
 
     www_authenticate_realm = "api"
 
     def get_serializer_class(self):
-        # Get the serializer from settings
+        """
+        If serializer_class is set, use it directly. Otherwise get the class from settings.
+        """
+
+        if self.serializer_class:
+            return self.serializer_class
         try:
             return import_string(self._serializer_class)
         except ImportError:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
+from rest_framework.test import APIRequestFactory
 
 from rest_framework_simplejwt import serializers
 from rest_framework_simplejwt.settings import api_settings
@@ -13,6 +14,7 @@ from rest_framework_simplejwt.utils import (
     datetime_from_epoch,
     datetime_to_epoch,
 )
+from rest_framework_simplejwt.views import TokenViewBase
 
 from .utils import APIViewTestCase, override_api_settings
 
@@ -431,3 +433,15 @@ class TestTokenBlacklistView(APIViewTestCase):
         del self.view_name
 
         self.assertEqual(res.status_code, 401)
+
+
+class TestCustomTokenView(APIViewTestCase):
+    def test_custom_view_class(self):
+        class CustomTokenView(TokenViewBase):
+            serializer_class = serializers.TokenObtainPairSerializer
+
+        factory = APIRequestFactory()
+        view = CustomTokenView.as_view()
+        request = factory.post("/", {}, format="json")
+        res = view(request)
+        self.assertEqual(res.status_code, 400)


### PR DESCRIPTION
In commit ed0f7b61ed45 serializer class configuration was moved into the
settings file in a way that made things significantly less flexible for
implementers of custom view classes. Instead of just defining
serializer_class (like with all other DRF view classes) it became necessary
to define both _serializer_class (which isn't defined at all in
TokenViewBase, which gives rather strange error messages) and then add
another line in settings.

This was also a breaking change, but it doesn't need to be. This commit
restores compatibility with just defining serializer_class (but the new way
to configure serializer classes is also supported).