### PR TITLE
Add `DEFAULT_PERMISSION_CLASSES` in REST_FRAMEWORK settings

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -33,7 +33,10 @@ authentication classes:
       'DEFAULT_AUTHENTICATION_CLASSES': (
           ...
           'rest_framework_simplejwt.authentication.JWTAuthentication',
-      )
+      ),
+     "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticated",
+        ),
       ...
   }
 


### PR DESCRIPTION
We also need to set the permission to is authenticated, otherwise the authentication doe not work