### PR TITLE
Fix i18n CI

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -54,7 +54,7 @@ jobs:
         file_pattern: rest_framework_simplejwt/locale/**
         commit_user_name: Andrew-Chen-Wang
         commit_user_email: acwangpython@gmail.com
-        commit_author: Andrew-Chen-Wang
+        commit_author: Andrew-Chen-Wang <acwangpython@gmail.com>
 
     - name: Tell whether locale updated
       if: steps.auto-commit-action.outputs.changes_detected == 'true'


### PR DESCRIPTION
```
fatal: --author 'Andrew-Chen-Wang' is not 'Name <email>' and matches no existing author
Error: Invalid status code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/index.js:17:19)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5) {
  code: 128
}
Error: Invalid status code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/index.js:17:19)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:283:5)
```

there seems to be problem with the author value.


https://github.com/stefanzweifel/git-auto-commit-action/blob/master/entrypoint.sh#L97