### PR TITLE
Allow customizing token JSON encoding

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -1,5 +1,6 @@
+import json
 from datetime import timedelta
-from typing import Union
+from typing import Optional, Type, Union
 
 import jwt
 from django.utils.translation import gettext_lazy as _
@@ -38,6 +39,7 @@ class TokenBackend:
         issuer=None,
         jwk_url: str = None,
         leeway: Union[float, int, timedelta] = None,
+        json_encoder: Optional[Type[json.JSONEncoder]] = None,
     ):
         self._validate_algorithm(algorithm)
 
@@ -53,6 +55,7 @@ class TokenBackend:
             self.jwks_client = None
 
         self.leeway = leeway
+        self.json_encoder = json_encoder
 
     def _validate_algorithm(self, algorithm):
         """
@@ -107,7 +110,12 @@ class TokenBackend:
         if self.issuer is not None:
             jwt_payload["iss"] = self.issuer
 
-        token = jwt.encode(jwt_payload, self.signing_key, algorithm=self.algorithm)
+        token = jwt.encode(
+            jwt_payload,
+            self.signing_key,
+            algorithm=self.algorithm,
+            json_encoder=self.json_encoder,
+        )
         if isinstance(token, bytes):
             # For PyJWT <= 1.7.1
             return token.decode("utf-8")

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -20,6 +20,7 @@ DEFAULTS = {
     "VERIFYING_KEY": "",
     "AUDIENCE": None,
     "ISSUER": None,
+    "JSON_ENCODER": None,
     "JWK_URL": None,
     "LEEWAY": 0,
     "AUTH_HEADER_TYPES": ("Bearer",),
@@ -44,6 +45,7 @@ DEFAULTS = {
 
 IMPORT_STRINGS = (
     "AUTH_TOKEN_CLASSES",
+    "JSON_ENCODER",
     "TOKEN_USER_CLASS",
     "USER_AUTHENTICATION_RULE",
 )

--- a/rest_framework_simplejwt/state.py
+++ b/rest_framework_simplejwt/state.py
@@ -9,4 +9,5 @@ token_backend = TokenBackend(
     api_settings.ISSUER,
     api_settings.JWK_URL,
     api_settings.LEEWAY,
+    api_settings.JSON_ENCODER,
 )


### PR DESCRIPTION
pyjwt has support for using a custom JSONEncoder class. Plumb that through, and add a setting to define the encoder from configuration.