### PR TITLE
Fixed issue #543

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -32,7 +32,7 @@ extra in the ``djangorestframework-simplejwt`` requirement:
 
 .. code-block:: console
 
-    $ pip install djangorestframework-simplejwt[crypto]
+  pip install djangorestframework-simplejwt[crypto]
 
 The ``djangorestframework-simplejwt[crypto]`` format is recommended in requirements
 files in projects using ``Simple JWT``, as a separate ``cryptography`` requirement

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -21,6 +21,26 @@ Simple JWT can be installed with pip::
 
   pip install djangorestframework-simplejwt
 
+
+Cryptographic Dependencies (Optional)
+-------------------------------------
+
+If you are planning on encoding or decoding tokens using certain digital
+signature algorithms (like RSA or ECDSA), you will need to install the
+cryptography_ library. This can be installed explicitly, or as a required
+extra in the ``Simple JWT`` requirement:
+
+.. code-block:: console
+
+    $ pip install djangorestframework-simplejwt[crypto]
+
+The ``djangorestframework-simplejwt[crypto]`` format is recommended in requirements
+files in projects using ``Simple JWT``, as a separate ``cryptography`` requirement
+line may later be mistaken for an unused requirement and removed.
+
+
+.. _`cryptography`: https://cryptography.io
+
 Then, your django project must be configured to use the library.  In
 ``settings.py``, add
 ``rest_framework_simplejwt.authentication.JWTAuthentication`` to the list of
@@ -59,16 +79,16 @@ allow API users to verify HMAC-signed tokens without having access to your
 signing key:
 
 .. code-block:: python
-  
+
   from rest_framework_simplejwt.views import TokenVerifyView
-  
+
   urlpatterns = [
       ...
       path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
       ...
   ]
 
-If you wish to use localizations/translations, simply add 
+If you wish to use localizations/translations, simply add
 ``rest_framework_simplejwt`` to ``INSTALLED_APPS``.
 
 .. code-block:: python

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -28,7 +28,7 @@ Cryptographic Dependencies (Optional)
 If you are planning on encoding or decoding tokens using certain digital
 signature algorithms (like RSA or ECDSA), you will need to install the
 cryptography_ library. This can be installed explicitly, or as a required
-extra in the ``Simple JWT`` requirement:
+extra in the ``djangorestframework-simplejwt`` requirement:
 
 .. code-block:: console
 
@@ -40,6 +40,9 @@ line may later be mistaken for an unused requirement and removed.
 
 
 .. _`cryptography`: https://cryptography.io
+
+Project Configuration
+---------------------
 
 Then, your django project must be configured to use the library.  In
 ``settings.py``, add

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -40,7 +40,6 @@ The ``djangorestframework-simplejwt[crypto]`` format is recommended in requireme
 files in projects using ``Simple JWT``, as a separate ``cryptography`` requirement
 line may later be mistaken for an unused requirement and removed.
 
-
 .. _`cryptography`: https://cryptography.io
 
 Project Configuration

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,7 +26,7 @@ Cryptographic Dependencies (Optional)
 -------------------------------------
 
 If you are planning on encoding or decoding tokens using certain digital
-signature algorithms (like RSA or ECDSA), you will need to install the
+signature algorithms (i.e. RSA and ECDSA; visit PyJWT for other algorithms), you will need to install the
 cryptography_ library. This can be installed explicitly, or as a required
 extra in the ``djangorestframework-simplejwt`` requirement:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -17,7 +17,9 @@ possible.
 Installation
 ------------
 
-Simple JWT can be installed with pip::
+Simple JWT can be installed with pip:
+
+.. code-block:: console
 
   pip install djangorestframework-simplejwt
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ extras_require = {
     "python-jose": [
         "python-jose==3.3.0",
     ],
+    "crypto": [
+        "cryptography>=3.3.1",
+    ],
 }
 
 extras_require["dev"] = (


### PR DESCRIPTION
Fixes #543
Allowing the optional installation of the cryptography package via `djangorestframework-simplejwt[crypto]` just like PyJWT.