### PR TITLE
Fix uncaught exception with JWK

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -10,7 +10,7 @@ from .exceptions import TokenBackendError
 from .utils import format_lazy
 
 try:
-    from jwt import PyJWKClient
+    from jwt import PyJWKClient, PyJWKClientError
 
     JWK_CLIENT_AVAILABLE = True
 except ImportError:
@@ -96,7 +96,10 @@ class TokenBackend:
             return self.signing_key
 
         if self.jwks_client:
-            return self.jwks_client.get_signing_key_from_jwt(token).key
+            try:
+                return self.jwks_client.get_signing_key_from_jwt(token).key
+            except PyJWKClientError as ex:
+                raise TokenBackendError(_("Token is invalid or expired")) from ex
 
         return self.verifying_key
 
@@ -145,5 +148,5 @@ class TokenBackend:
             )
         except InvalidAlgorithmError as ex:
             raise TokenBackendError(_("Invalid algorithm specified")) from ex
-        except InvalidTokenError:
-            raise TokenBackendError(_("Token is invalid or expired"))
+        except InvalidTokenError as ex:
+            raise TokenBackendError(_("Token is invalid or expired")) from ex

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 from jwt import PyJWS
 from jwt import __version__ as jwt_version
 from jwt import algorithms
+from jwt import PyJWKClientError
 
 from rest_framework_simplejwt.backends import JWK_CLIENT_AVAILABLE, TokenBackend
 from rest_framework_simplejwt.exceptions import TokenBackendError
@@ -291,6 +292,38 @@ class TestTokenBackend(TestCase):
             )
 
             self.assertEqual(jwk_token_backend.decode(token), self.payload)
+
+    @pytest.mark.skipif(
+        not JWK_CLIENT_AVAILABLE,
+        reason="PyJWT 1.7.1 doesn't have JWK client",
+    )
+    def test_decode_jwk_missing_key_raises_tokenbackenderror(self):
+        self.payload["exp"] = aware_utcnow() + timedelta(days=1)
+        self.payload["foo"] = "baz"
+        self.payload["aud"] = AUDIENCE
+        self.payload["iss"] = ISSUER
+
+        token = jwt.encode(
+            self.payload,
+            PRIVATE_KEY_2,
+            algorithm="RS256",
+            headers={"kid": "230498151c214b788dd97f22b85410a5"},
+        )
+
+        mock_jwk_module = mock.MagicMock()
+        with patch("rest_framework_simplejwt.backends.PyJWKClient") as mock_jwk_module:
+            mock_jwk_client = mock.MagicMock()
+
+            mock_jwk_module.return_value = mock_jwk_client
+            mock_jwk_client.get_signing_key_from_jwt.side_effect = PyJWKClientError("Unable to find a signing key that matches")
+
+            # Note the PRIV,PUB care is intentially the original pairing
+            jwk_token_backend = TokenBackend(
+                "RS256", PRIVATE_KEY, PUBLIC_KEY, AUDIENCE, ISSUER, JWK_URL
+            )
+
+            with self.assertRaisesRegex(TokenBackendError, "Token is invalid or expired"):
+                jwk_token_backend.decode(token)
 
     def test_decode_when_algorithm_not_available(self):
         token = jwt.encode(self.payload, PRIVATE_KEY, algorithm="RS256")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import jwt
 import pytest
 from django.test import TestCase
-from jwt import PyJWKClientError, PyJWS
+from jwt import PyJWS
 from jwt import __version__ as jwt_version
 from jwt import algorithms
 
@@ -314,7 +314,7 @@ class TestTokenBackend(TestCase):
             mock_jwk_client = mock.MagicMock()
 
             mock_jwk_module.return_value = mock_jwk_client
-            mock_jwk_client.get_signing_key_from_jwt.side_effect = PyJWKClientError(
+            mock_jwk_client.get_signing_key_from_jwt.side_effect = jwt.PyJWKClientError(
                 "Unable to find a signing key that matches"
             )
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,10 +7,9 @@ from unittest.mock import patch
 import jwt
 import pytest
 from django.test import TestCase
-from jwt import PyJWS
+from jwt import PyJWKClientError, PyJWS
 from jwt import __version__ as jwt_version
 from jwt import algorithms
-from jwt import PyJWKClientError
 
 from rest_framework_simplejwt.backends import JWK_CLIENT_AVAILABLE, TokenBackend
 from rest_framework_simplejwt.exceptions import TokenBackendError
@@ -315,14 +314,18 @@ class TestTokenBackend(TestCase):
             mock_jwk_client = mock.MagicMock()
 
             mock_jwk_module.return_value = mock_jwk_client
-            mock_jwk_client.get_signing_key_from_jwt.side_effect = PyJWKClientError("Unable to find a signing key that matches")
+            mock_jwk_client.get_signing_key_from_jwt.side_effect = PyJWKClientError(
+                "Unable to find a signing key that matches"
+            )
 
             # Note the PRIV,PUB care is intentially the original pairing
             jwk_token_backend = TokenBackend(
                 "RS256", PRIVATE_KEY, PUBLIC_KEY, AUDIENCE, ISSUER, JWK_URL
             )
 
-            with self.assertRaisesRegex(TokenBackendError, "Token is invalid or expired"):
+            with self.assertRaisesRegex(
+                TokenBackendError, "Token is invalid or expired"
+            ):
                 jwk_token_backend.decode(token)
 
     def test_decode_when_algorithm_not_available(self):


### PR DESCRIPTION
Fixes #599, needed to catch the `PyJWKClientError` raised when the JWK endpoint doesn't have the given key. Test added to raise the exception and verify that the exception is properly handled, based on the existing JWK test. 