### PR TITLE
use non-deprecated UTC timezone

### DIFF
--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -1,10 +1,10 @@
 from calendar import timegm
 from datetime import datetime
+from datetime.timezone import utc
 
 from django.conf import settings
 from django.utils.functional import lazy
 from django.utils.timezone import is_naive, make_aware
-from datetime.timezone import utc
 
 
 def make_utc(dt):

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -3,7 +3,8 @@ from datetime import datetime
 
 from django.conf import settings
 from django.utils.functional import lazy
-from django.utils.timezone import is_naive, make_aware, utc
+from django.utils.timezone import is_naive, make_aware
+from datetime.timezone import utc
 
 
 def make_utc(dt):

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -1,7 +1,5 @@
 from calendar import timegm
-from datetime import datetime
-from datetime.timezone import utc
-
+from datetime import timezone, datetime
 from django.conf import settings
 from django.utils.functional import lazy
 from django.utils.timezone import is_naive, make_aware
@@ -9,7 +7,7 @@ from django.utils.timezone import is_naive, make_aware
 
 def make_utc(dt):
     if settings.USE_TZ and is_naive(dt):
-        return make_aware(dt, timezone=utc)
+        return make_aware(dt, timezone=timezone.utc)
 
     return dt
 

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -1,5 +1,6 @@
 from calendar import timegm
-from datetime import timezone, datetime
+from datetime import datetime, timezone
+
 from django.conf import settings
 from django.utils.functional import lazy
 from django.utils.timezone import is_naive, make_aware


### PR DESCRIPTION
fixes RemovedInDjango50Warning