### PR TITLE
Allow superuser/staff to delete outstanding user token

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -32,7 +32,7 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
         return False
 
     def has_delete_permission(self, *args, **kwargs):
-        return False
+        return True
 
     def has_change_permission(self, request, obj=None):
         return request.method in ["GET", "HEAD"] and super().has_change_permission(


### PR DESCRIPTION
* As of now superuser or staff user can not delete outstanding user token