### PR TITLE
fix non standard implementation of __getattr__

### DIFF
--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -106,4 +106,6 @@ class TokenUser:
 
     def __getattr__(self, attr):
         """This acts as a backup attribute getter for custom claims defined in Token serializers."""
-        return self.token.get(attr, None)
+        if attr in self.token:
+            return self.token.get(attr)
+        raise AttributeError(f"'TokenUser' does not have an attribute {attr}")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+import pytest
 from django.test import TestCase
 
 from rest_framework_simplejwt.models import TokenUser
@@ -105,3 +106,13 @@ class TestTokenUser(TestCase):
 
     def test_get_username(self):
         self.assertEqual(self.user.get_username(), "deep-thought")
+
+    def test_getattr_returns_token_data(self):
+        self.assertEqual(self.user.__getattr__("some_other_stuff"), "arstarst")
+
+    def test_getattr_raises_attribute_error(self):
+        with pytest.raises(AttributeError):
+            self.user.__getattr__("_not_an_attribute")
+
+    def test_hasattr_for_missing_attribute(self):
+        self.assertFalse(hasattr(self.user, "_not_an_attribute"))


### PR DESCRIPTION
According to the [the docs](https://docs.python.org/3/reference/datamodel.html?highlight=__getattr__#object.__getattr__), a `__getattr__` magic method should either return a value for the requested attribute name, or raise `AttributeError`.

A `__getattr__` method was added to the `TokenUser` class that allows accessing keys on the token as if they were attributes of the `TokenUser` class.  In the current implementation, if the requested attribute name is not a key in the `token` dictionary, then `None` is returned instead of raising `AttributeError`.

When Django's auth backend `ModelBackend` does permission checks on a user object, it first checks for an attribute named `_perm_cache` with `hasattr`, then builds the cache if it doesn't exist.  Since `hasattr` incorrectly returns `True` for a `TokenUser` instance, the cache (which would have resolved to an empty set) is never created.  This ultimately results in a `TypeError` because `None` is not Iterable.
