### PR TITLE
Change has_delete_permission to True resulting admin user able to del…

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -32,7 +32,7 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
         return False
 
     def has_delete_permission(self, *args, **kwargs):
-        return False
+        return True
 
     def has_change_permission(self, request, obj=None):
         return request.method in ["GET", "HEAD"] and super().has_change_permission(


### PR DESCRIPTION
This PR fixes the user with outstanding token can't be deleted even with Admin access.