### PR TITLE
Improve typing

### DIFF
--- a/rest_framework_simplejwt/__init__.py
+++ b/rest_framework_simplejwt/__init__.py
@@ -4,4 +4,4 @@ try:
     __version__ = get_distribution("djangorestframework_simplejwt").version
 except DistributionNotFound:
     # package is not installed
-    __version__ = None
+    pass

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -7,7 +7,6 @@ from rest_framework import HTTP_HEADER_ENCODING, authentication
 from rest_framework.request import Request
 
 from .exceptions import AuthenticationFailed, InvalidToken, TokenError
-from .models import TokenUser
 from .settings import api_settings
 from .tokens import Token
 
@@ -83,7 +82,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         if len(parts) != 2:
             raise AuthenticationFailed(
-                cast(str, _("Authorization header must contain two space-delimited values")),
+                 _("Authorization header must contain two space-delimited values"),
                 code="bad_authorization_header",
             )
 
@@ -122,15 +121,15 @@ class JWTAuthentication(authentication.BaseAuthentication):
         try:
             user_id = validated_token[api_settings.USER_ID_CLAIM]
         except KeyError:
-            raise InvalidToken(cast(str, _("Token contained no recognizable user identification")))
+            raise InvalidToken(_("Token contained no recognizable user identification"))
 
         try:
             user = self.user_model.objects.get(**{api_settings.USER_ID_FIELD: user_id})
         except self.user_model.DoesNotExist:
-            raise AuthenticationFailed(cast(str, _("User not found")), code="user_not_found")
+            raise AuthenticationFailed(_("User not found"), code="user_not_found")
 
         if not user.is_active:
-            raise AuthenticationFailed(cast(str, _("User is inactive")), code="user_inactive")
+            raise AuthenticationFailed(_("User is inactive"), code="user_inactive")
 
         return user
 
@@ -149,7 +148,7 @@ class JWTStatelessUserAuthentication(JWTAuthentication):
         if api_settings.USER_ID_CLAIM not in validated_token:
             # The TokenUser class assumes tokens will have a recognizable user
             # identifier claim.
-            raise InvalidToken(cast(str,_("Token contained no recognizable user identification")))
+            raise InvalidToken(_("Token contained no recognizable user identification"))
 
         return cast(AbstractBaseUser, api_settings.TOKEN_USER_CLASS(validated_token))
 

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -33,7 +33,9 @@ class JWTAuthentication(authentication.BaseAuthentication):
         super().__init__(*args, **kwargs)
         self.user_model = get_user_model()
 
-    def authenticate(self, request: Request) -> Optional[Tuple[AbstractBaseUser, Token]]:
+    def authenticate(
+        self, request: Request
+    ) -> Optional[Tuple[AbstractBaseUser, Token]]:
         header = self.get_header(request)
         if header is None:
             return None
@@ -57,7 +59,9 @@ class JWTAuthentication(authentication.BaseAuthentication):
         Extracts the header containing the JSON web token from the given
         request.
         """
-        header = cast(Optional[Union[str, bytes]], request.META.get(api_settings.AUTH_HEADER_NAME))
+        header = cast(
+            Optional[Union[str, bytes]], request.META.get(api_settings.AUTH_HEADER_NAME)
+        )
 
         if isinstance(header, str):
             # Work around django test client oddness
@@ -82,7 +86,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         if len(parts) != 2:
             raise AuthenticationFailed(
-                 _("Authorization header must contain two space-delimited values"),
+                _("Authorization header must contain two space-delimited values"),
                 code="bad_authorization_header",
             )
 

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -8,8 +8,8 @@ from django.utils.translation import gettext_lazy as _
 from jwt import InvalidAlgorithmError, InvalidTokenError, algorithms
 
 from .exceptions import TokenBackendError
-from .utils import format_lazy
 from .tokens import TokenType
+from .utils import format_lazy
 
 try:
     from jwt import PyJWKClient, PyJWKClientError

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -9,8 +9,7 @@ from jwt import InvalidAlgorithmError, InvalidTokenError, algorithms
 
 from .exceptions import TokenBackendError
 from .utils import format_lazy
-
-TokenType = Union[str, bytes]
+from .tokens import TokenType
 
 try:
     from jwt import PyJWKClient, PyJWKClientError

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Optional
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
 

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Any
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
 
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     # DetailDictMixin is used with drf APIExceptions
     BASE_AuthenticationFailed = exceptions.APIException
 else:
+    _Detail = Any
     BASE_AuthenticationFailed = object
 
 

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -1,7 +1,12 @@
-from typing import Any, Dict, Optional, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
+
+if TYPE_CHECKING:
+    # DetailDictMixin is used with drf APIExceptions
+    BASE_AuthenticationFailed = exceptions.APIException
+else:
+    BASE_AuthenticationFailed = object
 
 
 class TokenError(Exception):
@@ -12,10 +17,7 @@ class TokenBackendError(Exception):
     pass
 
 
-class DetailDictMixin:
-    default_detail: str
-    default_code: str
-
+class DetailDictMixin(BASE_AuthenticationFailed):
     def __init__(
         self,
         detail: Union[Dict[str, Any], str, None] = None,
@@ -35,7 +37,7 @@ class DetailDictMixin:
         if code is not None:
             detail_dict["code"] = code
 
-        super().__init__(detail_dict)  # type: ignore
+        super().__init__(detail_dict)
 
 
 class AuthenticationFailed(DetailDictMixin, exceptions.AuthenticationFailed):

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
 
 if TYPE_CHECKING:
+    from rest_framework.exceptions import _Detail
     # DetailDictMixin is used with drf APIExceptions
     BASE_AuthenticationFailed = exceptions.APIException
 else:
@@ -20,7 +21,7 @@ class TokenBackendError(Exception):
 class DetailDictMixin(BASE_AuthenticationFailed):
     def __init__(
         self,
-        detail: Union[Dict[str, Any], str, None] = None,
+        detail: Optional[_Detail] = None,
         code: Optional[str] = None,
     ) -> None:
         """

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -1,9 +1,11 @@
-from typing import TYPE_CHECKING, Optional, Any
+from typing import TYPE_CHECKING, Any, Optional
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
 
 if TYPE_CHECKING:
     from rest_framework.exceptions import _Detail
+
     # DetailDictMixin is used with drf APIExceptions
     BASE_AuthenticationFailed = exceptions.APIException
 else:

--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from __future__ import annotations
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from django.contrib.auth import models as auth_models
 from django.db.models.manager import EmptyManager
@@ -27,7 +28,7 @@ class TokenUser:
     _groups = EmptyManager(auth_models.Group)
     _user_permissions = EmptyManager(auth_models.Permission)
 
-    def __init__(self, token: "Token") -> None:
+    def __init__(self, token: Token) -> None:
         self.token = token
 
     def __str__(self) -> str:
@@ -35,7 +36,7 @@ class TokenUser:
 
     @cached_property
     def id(self) -> Union[int, str]:
-        return self.token[api_settings.USER_ID_CLAIM]
+        return cast(Union[int, str], self.token[api_settings.USER_ID_CLAIM])
 
     @cached_property
     def pk(self) -> Union[int, str]:
@@ -77,11 +78,11 @@ class TokenUser:
         raise NotImplementedError("Token users have no DB representation")
 
     @property
-    def groups(self) -> auth_models.Group:
+    def groups(self) -> EmptyManager[auth_models.Group]:
         return self._groups
 
     @property
-    def user_permissions(self) -> auth_models.Permission:
+    def user_permissions(self) -> EmptyManager[auth_models.Permission]:
         return self._user_permissions
 
     def get_group_permissions(self, obj: Optional[object] = None) -> set:

--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from django.contrib.auth import models as auth_models
@@ -35,11 +36,11 @@ class TokenUser:
         return f"TokenUser {self.id}"
 
     @cached_property
-    def id(self) -> Union[int, str]:
+    def id(self) -> int | str:
         return cast(Union[int, str], self.token[api_settings.USER_ID_CLAIM])
 
     @cached_property
-    def pk(self) -> Union[int, str]:
+    def pk(self) -> int | str:
         return self.id
 
     @cached_property
@@ -85,16 +86,16 @@ class TokenUser:
     def user_permissions(self) -> EmptyManager[auth_models.Permission]:
         return self._user_permissions
 
-    def get_group_permissions(self, obj: Optional[object] = None) -> set:
+    def get_group_permissions(self, obj: object | None = None) -> set:
         return set()
 
-    def get_all_permissions(self, obj: Optional[object] = None) -> set:
+    def get_all_permissions(self, obj: object | None = None) -> set:
         return set()
 
-    def has_perm(self, perm: str, obj: Optional[object] = None) -> bool:
+    def has_perm(self, perm: str, obj: object | None = None) -> bool:
         return False
 
-    def has_perms(self, perm_list: List[str], obj: Optional[object] = None) -> bool:
+    def has_perms(self, perm_list: list[str], obj: object | None = None) -> bool:
         return False
 
     def has_module_perms(self, module: str) -> bool:
@@ -111,6 +112,6 @@ class TokenUser:
     def get_username(self) -> str:
         return self.username
 
-    def __getattr__(self, attr: str) -> Optional[Any]:
+    def __getattr__(self, attr: str) -> Any | None:
         """This acts as a backup attribute getter for custom claims defined in Token serializers."""
         return self.token.get(attr, None)

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type, TypeVar
+from typing import Any, Dict, Generic, Type, TypeVar, cast
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
@@ -7,18 +7,18 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ValidationError
 
-from .models import TokenUser
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
 
-AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
 if api_settings.BLACKLIST_AFTER_ROTATION:
     from .token_blacklist.models import BlacklistedToken
 
+T = TypeVar("T", bound=Token)
+
 
 class PasswordField(serializers.CharField):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("style", {})
 
         kwargs["style"]["input_type"] = "password"
@@ -27,15 +27,16 @@ class PasswordField(serializers.CharField):
         super().__init__(*args, **kwargs)
 
 
-class TokenObtainSerializer(serializers.Serializer):
+class TokenObtainSerializer(serializers.Serializer, Generic[T]):
     username_field = get_user_model().USERNAME_FIELD
-    token_class: Optional[Type[Token]] = None
+    token_class: Type[T]  # Subclasses should set this attribute
+    user: AbstractBaseUser
 
     default_error_messages = {
         "no_active_account": _("No active account found with the given credentials")
     }
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         self.fields[self.username_field] = serializers.CharField()
@@ -51,22 +52,21 @@ class TokenObtainSerializer(serializers.Serializer):
         except KeyError:
             pass
 
-        self.user = authenticate(**authenticate_kwargs)
+        self.user = authenticate(**authenticate_kwargs)  # type: ignore # Will be validated to not be none in the next line
 
         if not api_settings.USER_AUTHENTICATION_RULE(self.user):
             raise exceptions.AuthenticationFailed(
                 self.error_messages["no_active_account"],
                 "no_active_account",
             )
-
         return {}
 
     @classmethod
-    def get_token(cls, user: AuthUser) -> Token:
-        return cls.token_class.for_user(user)  # type: ignore
+    def get_token(cls, user: AbstractBaseUser) -> T:
+        return cast(T, cls.token_class.for_user(user))
 
 
-class TokenObtainPairSerializer(TokenObtainSerializer):
+class TokenObtainPairSerializer(TokenObtainSerializer[RefreshToken]):
     token_class = RefreshToken
 
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
@@ -78,12 +78,12 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
         data["access"] = str(refresh.access_token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            update_last_login(None, self.user)
+            update_last_login(None, self.user)  # type: ignore # Manual call can pass None
 
         return data
 
 
-class TokenObtainSlidingSerializer(TokenObtainSerializer):
+class TokenObtainSlidingSerializer(TokenObtainSerializer[SlidingToken]):
     token_class = SlidingToken
 
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
@@ -94,7 +94,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
         data["token"] = str(token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            update_last_login(None, self.user)
+            update_last_login(None, self.user)   # type: ignore # Manual call can pass None
 
         return data
 
@@ -156,7 +156,7 @@ class TokenVerifySerializer(serializers.Serializer):
             api_settings.BLACKLIST_AFTER_ROTATION
             and "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS
         ):
-            jti = token.get(api_settings.JTI_CLAIM)
+            jti: str = token.get(api_settings.JTI_CLAIM)
             if BlacklistedToken.objects.filter(token__jti=jti).exists():
                 raise ValidationError("Token is blacklisted")
 

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -52,7 +52,7 @@ class TokenObtainSerializer(serializers.Serializer, Generic[T]):
         except KeyError:
             pass
 
-        self.user = authenticate(**authenticate_kwargs)  # type: ignore # Will be validated to not be none in the next line
+        self.user = authenticate(**authenticate_kwargs)  # type: ignore # Will be validated to not be None in the next line
 
         if not api_settings.USER_AUTHENTICATION_RULE(self.user):
             raise exceptions.AuthenticationFailed(

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -10,7 +10,6 @@ from rest_framework.exceptions import ValidationError
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
 
-
 if api_settings.BLACKLIST_AFTER_ROTATION:
     from .token_blacklist.models import BlacklistedToken
 
@@ -94,7 +93,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer[SlidingToken]):
         data["token"] = str(token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            update_last_login(None, self.user)   # type: ignore # Manual call can pass None
+            update_last_login(None, self.user)  # type: ignore # Manual call can pass None
 
         return data
 

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from typing import Any, Dict
 
 from django.conf import settings
-from django.test.signals import setting_changed
+from django.core.signals import setting_changed
 from django.utils.translation import gettext_lazy as _
 from rest_framework.settings import APISettings as _APISettings
 
@@ -77,17 +77,20 @@ class APISettings(_APISettings):  # pragma: no cover
 
         return user_settings
 
+# type ignored because it expects DRF's settings.
+# See: https://github.com/typeddjango/djangorestframework-stubs/issues/375
+api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)  # type: ignore
 
-api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)
 
-
-def reload_api_settings(*args, **kwargs) -> None:  # pragma: no cover
+def reload_api_settings(*args: Any, **kwargs: Any) -> None:  # pragma: no cover
     global api_settings
 
     setting, value = kwargs["setting"], kwargs["value"]
 
     if setting == "SIMPLE_JWT":
-        api_settings = APISettings(value, DEFAULTS, IMPORT_STRINGS)
+        # type ignored because it expects DRF's settings.
+        # See: https://github.com/typeddjango/djangorestframework-stubs/issues/375
+        api_settings = APISettings(value, DEFAULTS, IMPORT_STRINGS)  # type: ignore
 
 
 setting_changed.connect(reload_api_settings)

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -77,6 +77,7 @@ class APISettings(_APISettings):  # pragma: no cover
 
         return user_settings
 
+
 # type ignored because it expects DRF's settings.
 # See: https://github.com/typeddjango/djangorestframework-stubs/issues/375
 api_settings = APISettings(USER_SETTINGS, DEFAULTS, IMPORT_STRINGS)  # type: ignore

--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -4,8 +4,9 @@ from typing import Any, List, Optional
 from django.contrib import admin
 from django.contrib.auth.models import AbstractBaseUser
 from django.db.models import QuerySet
-from django.utils.translation import gettext_lazy as _
 from django.http import HttpRequest
+from django.utils.translation import gettext_lazy as _
+
 from .models import BlacklistedToken, OutstandingToken
 
 

--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -1,16 +1,12 @@
 from datetime import datetime
-from typing import Any, List, Optional, TypeVar
+from typing import Any, List, Optional
 
 from django.contrib import admin
 from django.contrib.auth.models import AbstractBaseUser
 from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
-from rest_framework.request import Request
-
-from ..models import TokenUser
+from django.http import HttpRequest
 from .models import BlacklistedToken, OutstandingToken
-
-AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
 
 class OutstandingTokenAdmin(admin.ModelAdmin):
@@ -26,7 +22,7 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
     )
     ordering = ("user",)
 
-    def get_queryset(self, *args, **kwargs) -> QuerySet:
+    def get_queryset(self, *args: Any, **kwargs: Any) -> QuerySet:
         qs = super().get_queryset(*args, **kwargs)
 
         return qs.select_related("user")
@@ -34,17 +30,17 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
     # Read-only behavior defined below
     actions = None
 
-    def get_readonly_fields(self, *args, **kwargs) -> List[Any]:
+    def get_readonly_fields(self, *args: Any, **kwargs: Any) -> List[Any]:
         return [f.name for f in self.model._meta.fields]
 
-    def has_add_permission(self, *args, **kwargs) -> bool:
+    def has_add_permission(self, *args: Any, **kwargs: Any) -> bool:
         return False
 
-    def has_delete_permission(self, *args, **kwargs) -> bool:
+    def has_delete_permission(self, *args: Any, **kwargs: Any) -> bool:
         return False
 
     def has_change_permission(
-        self, request: Request, obj: Optional[object] = None
+        self, request: HttpRequest, obj: Optional[object] = None
     ) -> bool:
         return request.method in ["GET", "HEAD"] and super().has_change_permission(
             request, obj
@@ -68,7 +64,7 @@ class BlacklistedTokenAdmin(admin.ModelAdmin):
     )
     ordering = ("token__user",)
 
-    def get_queryset(self, *args, **kwargs) -> QuerySet:
+    def get_queryset(self, *args: Any, **kwargs: Any) -> QuerySet:
         qs = super().get_queryset(*args, **kwargs)
 
         return qs.select_related("token__user")
@@ -79,13 +75,13 @@ class BlacklistedTokenAdmin(admin.ModelAdmin):
     token_jti.short_description = _("jti")  # type: ignore
     token_jti.admin_order_field = "token__jti"  # type: ignore
 
-    def token_user(self, obj: BlacklistedToken) -> AuthUser:
+    def token_user(self, obj: BlacklistedToken) -> Optional[AbstractBaseUser]:
         return obj.token.user
 
     token_user.short_description = _("user")  # type: ignore
     token_user.admin_order_field = "token__user"  # type: ignore
 
-    def token_created_at(self, obj: BlacklistedToken) -> datetime:
+    def token_created_at(self, obj: BlacklistedToken) -> Optional[datetime]:
         return obj.token.created_at
 
     token_created_at.short_description = _("created at")  # type: ignore

--- a/rest_framework_simplejwt/token_blacklist/management/commands/flushexpiredtokens.py
+++ b/rest_framework_simplejwt/token_blacklist/management/commands/flushexpiredtokens.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from django.core.management.base import BaseCommand
 
 from rest_framework_simplejwt.utils import aware_utcnow

--- a/rest_framework_simplejwt/token_blacklist/management/commands/flushexpiredtokens.py
+++ b/rest_framework_simplejwt/token_blacklist/management/commands/flushexpiredtokens.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.core.management.base import BaseCommand
 
 from rest_framework_simplejwt.utils import aware_utcnow
@@ -8,5 +9,5 @@ from ...models import OutstandingToken
 class Command(BaseCommand):
     help = "Flushes any expired tokens in the outstanding token list"
 
-    def handle(self, *args, **kwargs) -> None:
+    def handle(self, *args: Any, **kwargs: Any) -> None:
         OutstandingToken.objects.filter(expires_at__lte=aware_utcnow()).delete()

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import AbstractBaseUser
 class OutstandingToken(models.Model):
     id = models.BigAutoField(primary_key=True, serialize=False)
     # The AUTH_USER_MODEL from the settings will always inherit from AbstractBaseUser
-    user: Optional[AbstractBaseUser] = models.ForeignKey(
+    user: Optional[AbstractBaseUser] = models.ForeignKey(  # type: ignore
         settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
     )
 

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -1,10 +1,13 @@
+from typing import TYPE_CHECKING, Optional
 from django.conf import settings
 from django.db import models
+from django.contrib.auth.models import AbstractBaseUser
 
 
 class OutstandingToken(models.Model):
     id = models.BigAutoField(primary_key=True, serialize=False)
-    user = models.ForeignKey(
+    # The AUTH_USER_MODEL from the settings will always inherit from AbstractBaseUser
+    user: Optional[AbstractBaseUser] = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
     )
 
@@ -20,8 +23,9 @@ class OutstandingToken(models.Model):
         #
         # Also see corresponding ticket:
         # https://github.com/encode/django-rest-framework/issues/705
+        # If we are TYPE_CHECKING, we don't want it to be abstract so django-stubs can pick it up
         abstract = (
-            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS
+            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS and not TYPE_CHECKING
         )
         ordering = ("user",)
 
@@ -44,8 +48,9 @@ class BlacklistedToken(models.Model):
         #
         # Also see corresponding ticket:
         # https://github.com/encode/django-rest-framework/issues/705
+        # If we are TYPE_CHECKING, we don't want it to be abstract so django-stubs can pick it up
         abstract = (
-            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS
+            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS and not TYPE_CHECKING
         )
 
     def __str__(self) -> str:

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -1,13 +1,11 @@
 from typing import TYPE_CHECKING, Optional
 from django.conf import settings
 from django.db import models
-from django.contrib.auth.models import AbstractBaseUser
 
 
 class OutstandingToken(models.Model):
     id = models.BigAutoField(primary_key=True, serialize=False)
-    # The AUTH_USER_MODEL from the settings will always inherit from AbstractBaseUser
-    user: Optional[AbstractBaseUser] = models.ForeignKey(  # type: ignore
+    user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
     )
 

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+
 from django.conf import settings
 from django.db import models
 
@@ -23,7 +24,8 @@ class OutstandingToken(models.Model):
         # https://github.com/encode/django-rest-framework/issues/705
         # If we are TYPE_CHECKING, we don't want it to be abstract so django-stubs can pick it up
         abstract = (
-            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS and not TYPE_CHECKING
+            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS
+            and not TYPE_CHECKING
         )
         ordering = ("user",)
 
@@ -48,7 +50,8 @@ class BlacklistedToken(models.Model):
         # https://github.com/encode/django-rest-framework/issues/705
         # If we are TYPE_CHECKING, we don't want it to be abstract so django-stubs can pick it up
         abstract = (
-            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS and not TYPE_CHECKING
+            "rest_framework_simplejwt.token_blacklist" not in settings.INSTALLED_APPS
+            and not TYPE_CHECKING
         )
 
     def __str__(self) -> str:

--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 from django.conf import settings
 from django.db import models
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
@@ -28,10 +29,10 @@ class Token:
     new JWT.
     """
 
-    token_type: Optional[str] = None
-    lifetime: Optional[timedelta] = None
+    token_type: str | None = None
+    lifetime: timedelta | None = None
 
-    def __init__(self, token: Optional[TokenType] = None, verify: bool = True) -> None:
+    def __init__(self, token: TokenType | None = None, verify: bool = True) -> None:
         """
         !!!! IMPORTANT !!!! MUST raise a TokenError with a user-facing error
         message if the given token is invalid, expired, or otherwise not safe
@@ -82,7 +83,7 @@ class Token:
     def __contains__(self, key: str) -> Any:
         return key in self.payload
 
-    def get(self, key: str, default: Optional[T] = None) -> T:
+    def get(self, key: str, default: T | None = None) -> T:
         return self.payload.get(key, default)
 
     def __str__(self) -> str:
@@ -142,8 +143,8 @@ class Token:
     def set_exp(
         self,
         claim: str = "exp",
-        from_time: Optional[datetime] = None,
-        lifetime: Optional[timedelta] = None,
+        from_time: datetime | None = None,
+        lifetime: timedelta | None = None,
     ) -> None:
         """
         Updates the expiration time of a token.
@@ -159,7 +160,7 @@ class Token:
 
         self.payload[claim] = datetime_to_epoch(from_time + lifetime)  # type: ignore  # Should be checked, not typesafe
 
-    def set_iat(self, claim: str = "iat", at_time: Optional[datetime] = None) -> None:
+    def set_iat(self, claim: str = "iat", at_time: datetime | None = None) -> None:
         """
         Updates the time at which the token was issued.
 
@@ -172,7 +173,7 @@ class Token:
         self.payload[claim] = datetime_to_epoch(at_time)
 
     def check_exp(
-        self, claim: str = "exp", current_time: Optional[datetime] = None
+        self, claim: str = "exp", current_time: datetime | None = None
     ) -> None:
         """
         Checks whether a timestamp value in the given claim has passed (since
@@ -207,7 +208,7 @@ class Token:
 
         return token
 
-    _token_backend: Optional[TokenBackend] = None
+    _token_backend: TokenBackend | None = None
 
     @property
     def token_backend(self) -> TokenBackend:
@@ -220,6 +221,7 @@ class Token:
     def get_token_backend(self) -> TokenBackend:
         # Backward compatibility.
         return self.token_backend
+
 
 if TYPE_CHECKING:
     TokenMixin = Token
@@ -235,7 +237,7 @@ class BlacklistMixin(TokenMixin):
     membership in a token blacklist.
     """
 
-    payload: Dict[str, Any]
+    payload: dict[str, Any]
 
     if "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS:
 
@@ -254,7 +256,7 @@ class BlacklistMixin(TokenMixin):
             if BlacklistedToken.objects.filter(token__jti=jti).exists():
                 raise TokenError(_("Token is blacklisted"))
 
-        def blacklist(self) -> Tuple[BlacklistedToken, bool]:
+        def blacklist(self) -> tuple[BlacklistedToken, bool]:
             """
             Ensures this token is included in the outstanding token list and
             adds it to the blacklist.

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 from datetime import datetime, timezone
-from typing import Callable
+from typing import Any, Callable
 
 from django.conf import settings
 from django.utils.functional import lazy
@@ -26,8 +26,8 @@ def datetime_from_epoch(ts: float) -> datetime:
     return make_utc(datetime.utcfromtimestamp(ts))
 
 
-def format_lazy(s: str, *args, **kwargs) -> str:
+def _format_lazy(s: str, *args: Any, **kwargs: Any) -> str:
     return s.format(*args, **kwargs)
 
 
-format_lazy: Callable = lazy(format_lazy, str)
+format_lazy: Callable = lazy(_format_lazy, str)

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional, Type, cast
+
 from django.utils.module_loading import import_string
 from rest_framework import generics, status
 from rest_framework.request import Request

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -1,8 +1,9 @@
+from typing import Any, Optional, Type, cast
 from django.utils.module_loading import import_string
 from rest_framework import generics, status
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import Serializer
+from rest_framework.serializers import BaseSerializer
 
 from .authentication import AUTH_HEADER_TYPES
 from .exceptions import InvalidToken, TokenError
@@ -13,12 +14,12 @@ class TokenViewBase(generics.GenericAPIView):
     permission_classes = ()
     authentication_classes = ()
 
-    serializer_class = None
+    serializer_class: Optional[Type[BaseSerializer]] = None
     _serializer_class = ""
 
     www_authenticate_realm = "api"
 
-    def get_serializer_class(self) -> Serializer:
+    def get_serializer_class(self) -> Type[BaseSerializer]:
         """
         If serializer_class is set, use it directly. Otherwise get the class from settings.
         """
@@ -26,7 +27,7 @@ class TokenViewBase(generics.GenericAPIView):
         if self.serializer_class:
             return self.serializer_class
         try:
-            return import_string(self._serializer_class)
+            return cast(Type[BaseSerializer], import_string(self._serializer_class))
         except ImportError:
             msg = "Could not import serializer '%s'" % self._serializer_class
             raise ImportError(msg)
@@ -37,7 +38,7 @@ class TokenViewBase(generics.GenericAPIView):
             self.www_authenticate_realm,
         )
 
-    def post(self, request: Request, *args, **kwargs) -> Response:
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         serializer = self.get_serializer(data=request.data)
 
         try:


### PR DESCRIPTION
# Description
Improvements to PR #683, with more strict type checking (using mypy) and usage of django-stubs / restframework-stubs.

This PR should be thoroughly reviewed, as I am not familiar with the inner works of the rest_framework_simplejwt module, and was merely focused on making types be coherent.

# Issues found
`rest_framework_simplejwt.tokens.Token.set_exp` method appears to not be typesafe:
```py
    def set_exp(
        self,
        claim: str = "exp",
        from_time: Optional[datetime] = None,
        lifetime: Optional[timedelta] = None,
    ) -> None:
        """
        Updates the expiration time of a token.

        See here:
        https://tools.ietf.org/html/rfc7519#section-4.1.4
        """
        if from_time is None:
            from_time = self.current_time

        if lifetime is None:
            lifetime = self.lifetime

        self.payload[claim] = datetime_to_epoch(from_time + lifetime)  # type: ignore  # Should be checked, not typesafe
```
Taking a look at the flow of the whole class, it appears that `lifetime` can reach the last line as `None` (because `self.lifetime` can also be `None`). If this happens, `from_time + lifetime` will raise an exception: `TypeError: unsupported operand type(s) for +: 'datetime.datetime' and 'NoneType'`. If there's some guarantee that this parameter will not be `None` here, I could not find it. This looks like a bug. I will leave the PR open as a draft to discuss this.

# Discussion
This PR mostly handles changes to types sugar syntax; however, actual code was changed in a few places, namely:
- The TokenBlacklist models are abstract depending on the settings; for django-stubs purposes, they are marked as not abstract if we are `TYPE_CHECKING`.
- The `TokenBackend` class takes a `signing_key` parameter that defaulted to `None`. This parameter appears to be used only with the jwt module; None keys will make jwt raise an exception; an empty key should instead be an empty string, so I changed this parameter to be `str = ""`.
- Multiple type casts where added. Even though these changes are reflected in the code, they also act as sugar syntax.
- Some imports where changed to be imported from the correct place that is supposed to export them:
  - `setting_changed` imported from `django.core.signals` instead of `django.test.signals`.

# Mypy configuration
The following configuration was used to type check this PR:
```toml
plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
exclude = [".*/migrations/[0-9]{4}_.*.py$"]
show_error_codes = true
# Be more strict
disallow_untyped_defs = true
disallow_any_unimported = true
no_implicit_optional = true
check_untyped_defs = true
# Warn everyhing
warn_redundant_casts = true
warn_unused_ignores = true
warn_no_return = true
warn_return_any = true
warn_unreachable = true
```

# Testing
This PR was developed and tested against an "empty" Django project (in order to get django-stubs to work). I had some trouble running tox against all versions, so I was hoping that CI/CD would take care of that for me. Tests passed against python `3.7.9`.

# Tags
Tagging @abczzz13 as the original contributor to typing.