### PR TITLE
the missing inverted comma cause error while installing

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -34,7 +34,7 @@ extra in the ``djangorestframework-simplejwt`` requirement:
 
 .. code-block:: console
 
-  pip install djangorestframework-simplejwt[crypto]
+  pip install "djangorestframework-simplejwt[crypto]"
 
 The ``djangorestframework-simplejwt[crypto]`` format is recommended in requirements
 files in projects using ``Simple JWT``, as a separate ``cryptography`` requirement


### PR DESCRIPTION
the missing inverted comma cause error while installing on linux i have added that helps to fix this issue 

....
error was 
! zsh: no matches found: djangorestframework-simplejwt[crypto]