### PR TITLE
Add the refresh token to the outstanding db after refreshing

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -13,8 +13,13 @@ from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
-if api_settings.BLACKLIST_AFTER_ROTATION:
-    from .token_blacklist.models import BlacklistedToken
+if api_settings.ROTATE_REFRESH_TOKENS:
+    from .token_blacklist.models import OutstandingToken
+    from .authentication import JWTAuthentication
+    from datetime import datetime
+
+    if api_settings.BLACKLIST_AFTER_ROTATION:
+        from .token_blacklist.models import BlacklistedToken
 
 
 class PasswordField(serializers.CharField):
@@ -122,6 +127,16 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()
+
+            auth = JWTAuthentication()
+            user = auth.get_user(validated_token=refresh)
+            OutstandingToken.objects.create(
+                user=user,
+                jti=refresh[api_settings.JTI_CLAIM],
+                token=str(refresh),
+                created_at=datetime.fromtimestamp(refresh["iat"]),
+                expires_at=datetime.fromtimestamp(refresh["exp"])
+            )
 
             data["refresh"] = str(refresh)
 


### PR DESCRIPTION
Fix the Issue #363 
By allowing the refreshtoken to be saved to the outstanding database after being refreshed.
It is useful for blacklisting every token for a precise user, if there's a leak of the token