### PR TITLE
add translation badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,3 +32,8 @@ Translations
 ------------
 
 Contribute translations directly with PRs or via inlang https://inlang.com/editor/github.com/jazzband/djangorestframework-simplejwt
+
+Translation status
+.. image:: https://inlang.com/badge?url=github.com/jazzband/djangorestframework-simplejwt
+   :target: https://inlang.com/editor/github.com/jazzband/djangorestframework-simplejwt?ref=badge
+   :alt: translation badge


### PR DESCRIPTION
Hey there, we want to get you more contributors to your repository!
Therefore, I added a badge which lets users contribute to your translations.

The badge endpoint allows you to create a dynamic badge that display real-time data on your project. For instance, you can use it to showcase your project's localization progress or the number of errors/warnings on your Github repository. This means that whenever someone views the badge, they will see the most up-to-date information about your project.

For your project, the badge looks like this:
(this image is already auto generated)

[![translation badge](https://inlang.com/badge?url=github.com/jazzband/djangorestframework-simplejwt)](https://inlang.com/editor/github.com/jazzband/djangorestframework-simplejwt?ref=badge)

We would be really happy if you decide to place this into your README to let people contribute to your translations 🥰

– Thank you,
Felix
