### PR TITLE
Revoke access token if user password is changed

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -135,7 +135,9 @@ class JWTAuthentication(authentication.BaseAuthentication):
             raise AuthenticationFailed(_("User is inactive"), code="user_inactive")
 
         if validated_token.get("hash_password") != get_md5_hash_password(user.password):
-            raise AuthenticationFailed(_("The user's password has been changed."), code="password_changed")
+            raise AuthenticationFailed(
+                _("The user's password has been changed."), code="password_changed"
+            )
 
         return user
 

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -10,6 +10,7 @@ from .exceptions import AuthenticationFailed, InvalidToken, TokenError
 from .models import TokenUser
 from .settings import api_settings
 from .tokens import Token
+from .utils import get_md5_hash_password
 
 AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
 
@@ -132,6 +133,9 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         if not user.is_active:
             raise AuthenticationFailed(_("User is inactive"), code="user_inactive")
+
+        if validated_token.get("hash_password") != get_md5_hash_password(user.password):
+            raise AuthenticationFailed(_("The user's password has been changed."), code="password_changed")
 
         return user
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -11,8 +11,13 @@ from .exceptions import TokenBackendError, TokenError
 from .models import TokenUser
 from .settings import api_settings
 from .token_blacklist.models import BlacklistedToken, OutstandingToken
-from .utils import (aware_utcnow, datetime_from_epoch, datetime_to_epoch,
-                    format_lazy, get_md5_hash_password)
+from .utils import (
+    aware_utcnow,
+    datetime_from_epoch,
+    datetime_to_epoch,
+    format_lazy,
+    get_md5_hash_password,
+)
 
 if TYPE_CHECKING:
     from .backends import TokenBackend

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -11,7 +11,8 @@ from .exceptions import TokenBackendError, TokenError
 from .models import TokenUser
 from .settings import api_settings
 from .token_blacklist.models import BlacklistedToken, OutstandingToken
-from .utils import aware_utcnow, datetime_from_epoch, datetime_to_epoch, format_lazy
+from .utils import (aware_utcnow, datetime_from_epoch, datetime_to_epoch,
+                    format_lazy, get_md5_hash_password)
 
 if TYPE_CHECKING:
     from .backends import TokenBackend
@@ -201,6 +202,7 @@ class Token:
 
         token = cls()
         token[api_settings.USER_ID_CLAIM] = user_id
+        token["hash_password"] = get_md5_hash_password(user.password)
 
         return token
 

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 from calendar import timegm
 from datetime import datetime, timezone
 from typing import Callable
@@ -5,6 +6,13 @@ from typing import Callable
 from django.conf import settings
 from django.utils.functional import lazy
 from django.utils.timezone import is_naive, make_aware
+
+
+def get_md5_hash_password(password: str) -> str:
+    """
+    Returns MD5 hash of the given password
+    """
+    return hashlib.md5(password.encode()).hexdigest().upper()
 
 
 def make_utc(dt: datetime) -> datetime:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,8 +6,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from rest_framework_simplejwt import authentication
-from rest_framework_simplejwt.exceptions import (AuthenticationFailed,
-                                                 InvalidToken)
+from rest_framework_simplejwt.exceptions import AuthenticationFailed, InvalidToken
 from rest_framework_simplejwt.models import TokenUser
 from rest_framework_simplejwt.settings import api_settings
 from rest_framework_simplejwt.tokens import AccessToken, SlidingToken

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,10 +6,12 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from rest_framework_simplejwt import authentication
-from rest_framework_simplejwt.exceptions import AuthenticationFailed, InvalidToken
+from rest_framework_simplejwt.exceptions import (AuthenticationFailed,
+                                                 InvalidToken)
 from rest_framework_simplejwt.models import TokenUser
 from rest_framework_simplejwt.settings import api_settings
 from rest_framework_simplejwt.tokens import AccessToken, SlidingToken
+from rest_framework_simplejwt.utils import get_md5_hash_password
 
 from .utils import override_api_settings
 
@@ -152,6 +154,12 @@ class TestJWTAuthentication(TestCase):
 
         u.is_active = True
         u.save()
+
+        # Should raise exception if password hash is different
+        with self.assertRaises(AuthenticationFailed):
+            self.backend.get_user(payload)
+
+        payload["hash_password"] = get_md5_hash_password(u.password)
 
         # Otherwise, should return correct user
         self.assertEqual(self.backend.get_user(payload).id, u.id)


### PR DESCRIPTION
In this pull request, I have added a new key to the jwt token payload called hash_password, which is generated through the following function:

```
def get_md5_hash_password(password: str) -> str:
    """
    Returns MD5 hash of the given password
    """
    return hashlib.md5(password.encode()).hexdigest().upper()

```
Then, during jwt token validation, I check if the current user password matches the value in the hash_password field of the jwt token payload. If these two values are not equal, it means that the user has changed their password.

Additionally, the tests related to jwt token validation have also been updated accordingly with these changes.