### PR TITLE
update supported versions docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,9 +6,9 @@ Getting started
 Requirements
 ------------
 
-* Python (3.7, 3.8, 3.9, 3.10)
-* Django (2.2, 3.1, 3.2, 4.0)
-* Django REST Framework (3.10, 3.11, 3.12, 3.13)
+* Python (3.7, 3.8, 3.9, 3.10, 3.11)
+* Django (2.2, 3.1, 3.2, 4.0, 4.1)
+* Django REST Framework (3.10, 3.11, 3.12, 3.13, 3.14)
 
 These are the officially supported python and package versions.  Other versions
 will probably work.  You're free to modify the tox config and see what is


### PR DESCRIPTION
Pretty straightforward, this PR just updates the [requirements](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/getting_started.html#installation) section of the [getting started docs](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/getting_started.html) to match what's tested against in the [test.yaml](https://github.com/jazzband/djangorestframework-simplejwt/blob/f298efa860b4ef097d8448e1515c98d40e54a3e4/.github/workflows/test.yml) workflow.

These versions are added to the docs...

- python 3.11
- django 4.1
- DRF 3.14