### PR TITLE
Add support for Django 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        django-version: ['3.2', '4.0', '4.1']
+        django-version: ['3.2', '4.0', '4.1', '4.2']
         drf-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,9 +6,9 @@ Getting started
 Requirements
 ------------
 
-* Python (3.7, 3.8, 3.9, 3.10)
-* Django (2.2, 3.1, 3.2, 4.0)
-* Django REST Framework (3.10, 3.11, 3.12, 3.13)
+* Python (3.8, 3.9, 3.10, 3.11)
+* Django (3.2, 4.0, 4.1, 4.2)
+* Django REST Framework (3.10, 3.11, 3.12, 3.13, 3.14)
 
 These are the officially supported python and package versions.  Other versions
 will probably work.  You're free to modify the tox config and see what is

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
     author="David Sanders",
     author_email="davesque@gmail.com",
     install_requires=[
-        "django",
-        "djangorestframework",
+        "django>=3.2",
+        "djangorestframework>=3.10",
         "pyjwt>=1.7.1,<3",
     ],
     python_requires=">=3.7",
@@ -71,6 +71,7 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
     py{37,38,39,310}-dj{32}-drf{311,312,313}-pyjwt{171,2}-tests
-    py{38,39,310}-dj{40,41}-drf313-pyjwt{171,2}-tests
-    py311-dj{41}-drf{313,314}-pyjwt{171,2}-tests
+    py{38,39,310}-dj{40,41,42}-drf313-pyjwt{171,2}-tests
+    py311-dj{41,42}-drf{313,314}-pyjwt{171,2}-tests
     docs
 
 [gh-actions]
@@ -18,6 +18,7 @@ DJANGO=
     3.2: dj32
     4.0: dj40
     4.1: dj41
+    4.2: dj42
 DRF=
     3.10: drf310
     3.11: drf311
@@ -36,6 +37,7 @@ deps=
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<4.3
     drf310: djangorestframework>=3.10,<3.11
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13


### PR DESCRIPTION
Closes #706 

Closes #707

- Add support for Django 4.2
- Add minimum bound on Django and DRF requirement matching the minimum version tested in CI
- Fix documentation on supported Python/Django/DRF versions (#706)