### PR TITLE
Added related_name to both OutstandingToken as well as BlacklistedToken

### DIFF
--- a/rest_framework_simplejwt/token_blacklist/models.py
+++ b/rest_framework_simplejwt/token_blacklist/models.py
@@ -5,7 +5,7 @@ from django.db import models
 class OutstandingToken(models.Model):
     id = models.BigAutoField(primary_key=True, serialize=False)
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
+        settings.AUTH_USER_MODEL, related_name="outstanding_tokens", on_delete=models.SET_NULL, null=True, blank=True
     )
 
     jti = models.CharField(unique=True, max_length=255)
@@ -34,7 +34,7 @@ class OutstandingToken(models.Model):
 
 class BlacklistedToken(models.Model):
     id = models.BigAutoField(primary_key=True, serialize=False)
-    token = models.OneToOneField(OutstandingToken, on_delete=models.CASCADE)
+    token = models.OneToOneField(OutstandingToken, related_name="blacklisted_token", on_delete=models.CASCADE)
 
     blacklisted_at = models.DateTimeField(auto_now_add=True)
 


### PR DESCRIPTION
Not a huge change, but this would make the reverse relation reference easier from both the user perspective as well as the OutstandingToken perspective:

`user.outstandingtoken_set` becomes `user.outstanding_tokens`

The same for the BlacklistedToken
