### PR TITLE
user_logged_in instead of update_last_login

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -79,7 +79,12 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
         data["access"] = str(refresh.access_token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            user_logged_in.send(sender=self.user.__class__, user=self.user, data=data, request=self.context.get('request'))
+            user_logged_in.send(
+                sender=self.user.__class__,
+                user=self.user,
+                data=data,
+                request=self.context.get("request"),
+            )
 
         return data
 
@@ -95,7 +100,12 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
         data["token"] = str(token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            user_logged_in.send(sender=self.user.__class__, user=self.user, data=data, request=self.context.get('request'))
+            user_logged_in.send(
+                sender=self.user.__class__,
+                user=self.user,
+                data=data,
+                request=self.context.get("request"),
+            )
 
         return data
 

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional, Type, TypeVar
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
-from django.contrib.auth.models import AbstractBaseUser, update_last_login
+from django.contrib.auth.models import AbstractBaseUser
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ValidationError
@@ -10,6 +10,7 @@ from rest_framework.exceptions import ValidationError
 from .models import TokenUser
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
+from django.contrib.auth.signals import user_logged_in
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
@@ -78,7 +79,7 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
         data["access"] = str(refresh.access_token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            update_last_login(None, self.user)
+            user_logged_in.send(sender=self.user.__class__, user=self.user)
 
         return data
 
@@ -94,7 +95,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
         data["token"] = str(token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            update_last_login(None, self.user)
+            user_logged_in.send(sender=self.user.__class__, user=self.user)
 
         return data
 

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Type, TypeVar
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import AbstractBaseUser
+from django.contrib.auth.signals import user_logged_in
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ValidationError
@@ -10,7 +11,6 @@ from rest_framework.exceptions import ValidationError
 from .models import TokenUser
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
-from django.contrib.auth.signals import user_logged_in
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -80,7 +80,7 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
 
         if api_settings.UPDATE_LAST_LOGIN:
             user_logged_in.send(
-                sender=self.user.__class__,
+                sender=self.__class__,
                 user=self.user,
                 data=data,
                 request=self.context.get("request"),
@@ -101,7 +101,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
 
         if api_settings.UPDATE_LAST_LOGIN:
             user_logged_in.send(
-                sender=self.user.__class__,
+                sender=self.__class__,
                 user=self.user,
                 data=data,
                 request=self.context.get("request"),

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -79,7 +79,7 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
         data["access"] = str(refresh.access_token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            user_logged_in.send(sender=self.user.__class__, user=self.user)
+            user_logged_in.send(sender=self.user.__class__, user=self.user, data=data, request=self.context.get('request'))
 
         return data
 
@@ -95,7 +95,7 @@ class TokenObtainSlidingSerializer(TokenObtainSerializer):
         data["token"] = str(token)
 
         if api_settings.UPDATE_LAST_LOGIN:
-            user_logged_in.send(sender=self.user.__class__, user=self.user)
+            user_logged_in.send(sender=self.user.__class__, user=self.user, data=data, request=self.context.get('request'))
 
         return data
 


### PR DESCRIPTION
I did not see a reason to call `update_last_login` directly.

This allows code like the following to function properly.

```
# my_app.signals
# Track last_login & previous_login (custom field)
def update_last_and_previous_login(sender, user, **kwargs):
    User.objects.filter(pk=user.pk).update(previous_login=user.last_login, last_login=timezone.now())

user_logged_in.disconnect(update_last_login, dispatch_uid='update_last_login')
user_logged_in.connect(update_last_and_previous_login, dispatch_uid='update_last_and_previous_login')
```

I also thought of providing the `data` variable as a kwarg to allow even more flexibility.

`user_logged_in.send(sender=self.user.__class__, user=self.user, **data)` or `user_logged_in.send(sender=self.user.__class__, user=self.user, data=data)`