### PR TITLE
Declare support for type checking (closes #664)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include LICENSE.txt
+include rest_framework_simplejwt/py.typed
 recursive-include rest_framework_simplejwt/locale *.mo
 recursive-include rest_framework_simplejwt/locale *.po
 recursive-exclude * __pycache__


### PR DESCRIPTION
Added py.typed file so that linters such as `mypy` know the package has typehints.

Relevant PEP: https://peps.python.org/pep-0561/#packaging-type-information

I haven't used setuptools much, but I believe the configuration provided is enough to package the py.typed file with the package; but please do confirm it.