### PR TITLE
Fix tests

### DIFF
--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -5,7 +5,6 @@ from typing import Callable
 
 from django.conf import settings
 from django.utils.functional import lazy
-from django.utils.timezone import is_naive, make_aware
 
 
 def get_md5_hash_password(password: str) -> str:
@@ -16,8 +15,8 @@ def get_md5_hash_password(password: str) -> str:
 
 
 def make_utc(dt: datetime) -> datetime:
-    if settings.USE_TZ and is_naive(dt):
-        return make_aware(dt, timezone=timezone.utc)
+    if settings.USE_TZ and dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
 
     return dt
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,16 +1,15 @@
 from importlib import reload
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase
-from pkg_resources import DistributionNotFound
 
 
 class TestInit(SimpleTestCase):
     def test_package_is_not_installed(self):
         with patch(
-            "pkg_resources.get_distribution", Mock(side_effect=DistributionNotFound)
+            "importlib.metadata.version", Mock(side_effect=PackageNotFoundError)
         ):
-            # Import package mock package is not installed
             import rest_framework_simplejwt.__init__
 
             self.assertEqual(rest_framework_simplejwt.__init__.__version__, None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from django.test import TestCase
-from django.utils import timezone
+from datetime import timezone
 from freezegun import freeze_time
 
 from rest_framework_simplejwt.utils import (
@@ -24,11 +24,11 @@ class TestMakeUtc(TestCase):
 
         with self.settings(USE_TZ=False):
             dt = make_utc(dt)
-            self.assertTrue(timezone.is_naive(dt))
+            self.assertTrue(dt.tzinfo is None)
 
         with self.settings(USE_TZ=True):
             dt = make_utc(dt)
-            self.assertTrue(timezone.is_aware(dt))
+            self.assertTrue(dt.tzinfo is not None)
             self.assertEqual(dt.utcoffset(), timedelta(seconds=0))
 
 
@@ -39,9 +39,7 @@ class TestAwareUtcnow(TestCase):
         with freeze_time(now):
             # Should return aware utcnow if USE_TZ == True
             with self.settings(USE_TZ=True):
-                self.assertEqual(
-                    timezone.make_aware(now, timezone=timezone.utc), aware_utcnow()
-                )
+                self.assertEqual(now.replace(tzinfo=timezone.utc), aware_utcnow())
 
             # Should return naive utcnow if USE_TZ == False
             with self.settings(USE_TZ=False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.test import TestCase
-from datetime import timezone
 from freezegun import freeze_time
 
 from rest_framework_simplejwt.utils import (


### PR DESCRIPTION
This fixes a couple test issues:

1. `rest_framework_simplejwt/__init__.py` was changed to throw `PackageNotFoundError`
2. Django 4.1 deprecatating the `django.utils.timezone.utc` alias. This moves timezone handling to `datetime.timezone.utc` directly.