### PR TITLE
Improve type of `Token.for_user` to allow subclasses

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -197,7 +197,7 @@ class Token:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
-    def for_user(cls, user: AuthUser) -> "Token":
+    def for_user(cls: Type[T], user: AuthUser) -> T:
         """
         Returns an authorization token for the given user that will be provided
         after authenticating the user's credentials.


### PR DESCRIPTION
The same approach is already used in `BlacklistMixin`. The issue with existing `Token` return type can be demonstrated by

```python
from django.contrib.auth.models import User
from rest_framework_simplejwt.tokens import RefreshToken

user: User
token = RefreshToken.for_user(user)
token.access_token  # E: "Token" has no attribute "access_token"  [attr-defined]
```