### PR TITLE
Auto Update Locale Files

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -17,30 +17,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout Repository
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-        cache: 'pip'
-        cache-dependency-path: setup.py
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: setup.py
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y gettext 
-        python -m pip install --upgrade pip wheel setuptools
-        pip install -e .[dev]
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y gettext 
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -e .[dev]
 
-    - name: Run locale Update Script
-      run: python scripts/i18n_updater.py
+      - name: Run locale Update Script
+        run: python scripts/i18n_updater.py
 
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
-      with:
-        branch: i18n-auto-update
-        title: "[i18n] Update"
-        body: "Updated locale files on trunk"
-        commit-message: "Update locale files"
-        add-paths: rest_framework_simplejwt/locale/**
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: i18n-auto-update
+          title: "[i18n] Update"
+          body: "Updated locale files on trunk"
+          commit-message: "Update locale files"
+          add-paths: rest_framework_simplejwt/locale/**
+          delete-branch: true

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -6,12 +6,12 @@ on:
       - main
       - master
 
-permissions:
-  pull-requests: write
-  contents: write
 
 jobs:
   locale-updater:
+    permissions:
+      pull-requests: write
+      contents: write
     if: github.repository == 'jazzband/djangorestframework-simplejwt'
     name: Locale updater
     runs-on: ubuntu-latest

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,41 +1,31 @@
-name: Locale Updater
+name: Update locale files
 
 on:
   push:
     branches:
-      - master
       - main
+      - master
+
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
   locale-updater:
+    if: github.repository == 'jazzband/djangorestframework-simplejwt'
     name: Locale updater
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.head_ref }}
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
+    - name: Checkout Repository
+      uses: actions/checkout@v4
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: Cache
-      uses: actions/cache@v2
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key:
-          3.9-v1-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          3.9-v1-
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: setup.py
 
     - name: Install dependencies
       run: |
@@ -43,21 +33,14 @@ jobs:
         python -m pip install --upgrade pip wheel setuptools
         pip install -e .[dev]
 
-    - name: Run locale
-      working-directory: rest_framework_simplejwt
-      run: |
-        python ../scripts/i18n_updater.py
+    - name: Run locale Update Script
+      run: python scripts/i18n_updater.py
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
-      id: auto-commit-action
+      uses: peter-evans/create-pull-request@v6
       with:
         branch: i18n-auto-update
         title: "[i18n] Update"
-        body: "Updated locale files on master branch"
+        body: "Updated locale files on trunk"
         commit-message: "Update locale files"
         add-paths: rest_framework_simplejwt/locale/**
-        delete-branch: true
-
-    - name: Tell whether locale updated
-      run: echo "Locale files updated"


### PR DESCRIPTION
This PR update workflow permissions to automatically create a PR to trunk (master/main) when locale files need to be updated. It also cleans up the existing workflow with newer dependencies including:

    python 3.9 -> 3.12
    action/checkout@v2 -> action/checkout@v4
    create-pull-request@v3 -> create-pull-requests@v6
    actions/setup-python@v2 -> actions/setup-python@v5

With the updated dependencies we now cache python dependencies with the built-in functionality instead of doing so manually. 

We also only run this action if it's push to the jazzband org repo

This PR closes #462 