### PR TITLE
Prevent incorrect usage of Token.for_user

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -63,7 +63,7 @@ class TokenObtainSerializer(serializers.Serializer):
 
     @classmethod
     def get_token(cls, user: AuthUser) -> Token:
-        return cls.token_class.for_user(user)  # type: ignore
+        return cls.token_class.for_validated_user(user)  # type: ignore
 
 
 class TokenObtainPairSerializer(TokenObtainSerializer):

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -210,6 +210,12 @@ class Token:
 
     @classmethod
     def for_validated_user(cls: Type[T], user: AuthUser) -> T:
+        """
+        Returns an authorization token for the given user.
+        
+        This DOES NOT check if the provided user validates the ``USER_AUTHENTICATION_RULE``.
+        Use :meth:`for_user` to have the user validated.
+        """
         user_id = getattr(user, api_settings.USER_ID_FIELD)
         if not isinstance(user_id, int):
             user_id = str(user_id)

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -206,6 +206,11 @@ class Token:
         if not isinstance(user_id, int):
             user_id = str(user_id)
 
+        # Prevent incorrect usage of Token.for_user (when creating tokens manually)
+        # see https://github.com/jazzband/djangorestframework-simplejwt/issues/779
+        if not api_settings.USER_AUTHENTICATION_RULE(user):
+            raise TokenError(_("Token is invalid or expired"))
+
         token = cls()
         token[api_settings.USER_ID_CLAIM] = user_id
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -212,7 +212,7 @@ class Token:
     def for_validated_user(cls: Type[T], user: AuthUser) -> T:
         """
         Returns an authorization token for the given user.
-        
+
         This DOES NOT check if the provided user validates the ``USER_AUTHENTICATION_RULE``.
         Use :meth:`for_user` to have the user validated.
         """

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -390,6 +390,15 @@ class TestToken(TestCase):
         token = MyToken.for_user(self.user)
         self.assertEqual(token[api_settings.USER_ID_CLAIM], self.username)
 
+    def test_for_user_fails_if_is_active_false(self):
+        # works with is_active=True
+        token = MyToken.for_user(self.user)
+
+        # fails with is_active=False
+        self.user.is_active = False
+        with self.assertRaises(TokenError):
+            token = MyToken.for_user(self.user)
+
     @override_api_settings(CHECK_REVOKE_TOKEN=True)
     def test_revoke_token_claim_included_in_authorization_token(self):
         token = MyToken.for_user(self.user)


### PR DESCRIPTION
Attempt to address #779 

- `for_validated_user()` replaces current `for_user()` method (no functionality change, it is just a rename)
- `for_user()` now checks `user.is_active` flag thanks the `api_settings.USER_AUTHENTICATION_RULE` callable