### PR TITLE
Fix the `Null` value of the `OutstandingToken` of the `BlacklistMixin.blacklist`

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -265,11 +265,14 @@ class BlacklistMixin(Generic[T]):
             """
             jti = self.payload[api_settings.JTI_CLAIM]
             exp = self.payload["exp"]
+            user_id = self.payload.get(api_settings.USER_ID_CLAIM)
 
             # Ensure outstanding token exists with given jti
             token, _ = OutstandingToken.objects.get_or_create(
                 jti=jti,
                 defaults={
+                    "user_id": user_id,
+                    "created_at": self.current_time,
                     "token": str(self),
                     "expires_at": datetime_from_epoch(exp),
                 },

--- a/tests/test_token_blacklist.py
+++ b/tests/test_token_blacklist.py
@@ -146,6 +146,20 @@ class TestTokenBlacklist(TestCase):
         self.assertEqual(str(outstanding), expected_outstanding_str)
         self.assertEqual(str(blacklisted), expected_blacklisted_str)
 
+    def test_outstanding_token_and_blacklisted_token_created_at(self):
+        token = RefreshToken.for_user(self.user)
+
+        token.blacklist()
+        outstanding_token = OutstandingToken.objects.get(token=token)
+        self.assertEqual(outstanding_token.created_at, token.current_time)
+
+    def test_outstanding_token_and_blacklisted_token_user(self):
+        token = RefreshToken.for_user(self.user)
+
+        token.blacklist()
+        outstanding_token = OutstandingToken.objects.get(token=token)
+        self.assertEqual(outstanding_token.user, self.user)
+
 
 class TestTokenBlacklistFlushExpiredTokens(TestCase):
     def setUp(self):


### PR DESCRIPTION
# I have made things!
I agree with what is registered in the issue below.

I confirmed that `user_id` and `created_at` were not registered in `TokenRefreshView`, and added `user_id` and `created_at` to `OutstandingTokens` in the `BlacklistMixin.blacklist` function.

## Related issues
- https://github.com/jazzband/djangorestframework-simplejwt/issues/799
