### PR TITLE
Fix: Disable refresh token for inactive user.

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -5,7 +5,7 @@ from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import AbstractBaseUser, update_last_login
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
-from rest_framework.exceptions import ValidationError, AuthenticationFailed
+from rest_framework.exceptions import AuthenticationFailed, ValidationError
 
 from .models import TokenUser
 from .settings import api_settings
@@ -112,7 +112,11 @@ class TokenRefreshSerializer(serializers.Serializer):
         refresh = self.token_class(attrs["refresh"])
 
         user_id = refresh.payload.get(api_settings.USER_ID_CLAIM, None)
-        if user_id and (user := get_user_model().objects.get(**{api_settings.USER_ID_FIELD: user_id})):
+        if user_id and (
+            user := get_user_model().objects.get(
+                **{api_settings.USER_ID_FIELD: user_id}
+            )
+        ):
             if not api_settings.USER_AUTHENTICATION_RULE(user):
                 raise AuthenticationFailed(
                     self.error_messages["no_active_account"],

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -105,7 +105,7 @@ class TokenRefreshSerializer(serializers.Serializer):
     token_class = RefreshToken
 
     default_error_messages = {
-        "no_active_account": _("No active account found with the given credentials")
+        "no_active_account": _("No active account found for the given token.")
     }
 
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -5,7 +5,7 @@ from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.models import AbstractBaseUser, update_last_login
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError, AuthenticationFailed
 
 from .models import TokenUser
 from .settings import api_settings
@@ -104,8 +104,20 @@ class TokenRefreshSerializer(serializers.Serializer):
     access = serializers.CharField(read_only=True)
     token_class = RefreshToken
 
+    default_error_messages = {
+        "no_active_account": _("No active account found with the given credentials")
+    }
+
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
         refresh = self.token_class(attrs["refresh"])
+
+        user_id = refresh.payload.get(api_settings.USER_ID_CLAIM, None)
+        if user_id and (user := get_user_model().objects.get(**{api_settings.USER_ID_FIELD: user_id})):
+            if not api_settings.USER_AUTHENTICATION_RULE(user):
+                raise AuthenticationFailed(
+                    self.error_messages["no_active_account"],
+                    "no_active_account",
+                )
 
         data = {"access": str(refresh.access_token)}
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -247,19 +247,7 @@ class BlacklistMixin(Generic[T]):
         def verify(self, *args, **kwargs) -> None:
             self.check_blacklist()
 
-            self.check_user_active()
-
             super().verify(*args, **kwargs)  # type: ignore
-
-        def check_user_active(self):
-            user_id = self.payload.get(api_settings.USER_ID_CLAIM, None)
-            if (
-                user_id
-                and not get_user_model()
-                .objects.get(**{api_settings.USER_ID_FIELD: user_id})
-                .is_active
-            ):
-                raise TokenError(_("User is inactive"))
 
         def check_blacklist(self) -> None:
             """

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Type, TypeVar
 from uuid import uuid4
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -253,7 +253,12 @@ class BlacklistMixin(Generic[T]):
 
         def check_user_active(self):
             user_id = self.payload.get(api_settings.USER_ID_CLAIM, None)
-            if user_id and not get_user_model().objects.get(**{api_settings.USER_ID_FIELD: user_id}).is_active:
+            if (
+                user_id
+                and not get_user_model()
+                .objects.get(**{api_settings.USER_ID_FIELD: user_id})
+                .is_active
+            ):
                 raise TokenError(_("User is inactive"))
 
         def check_blacklist(self) -> None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -4,9 +4,9 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core import exceptions as django_exceptions
 from django.test import TestCase
 from rest_framework import exceptions as drf_exceptions
-from django.core import exceptions as django_exceptions
 
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import (
@@ -267,7 +267,6 @@ class TestTokenRefreshSerializer(TestCase):
             s.is_valid()
 
         self.assertIn("does not exist", str(e.exception))
-
 
     def test_it_should_raise_error_for_inactive_users(self):
         refresh = RefreshToken.for_user(self.user)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework import exceptions as drf_exceptions
+from django.core import exceptions as django_exceptions
 
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import (
@@ -255,6 +256,18 @@ class TestTokenRefreshSerializer(TestCase):
             username=self.username,
             password=self.password,
         )
+
+    def test_it_should_raise_error_for_deleted_users(self):
+        refresh = RefreshToken.for_user(self.user)
+        self.user.delete()
+
+        s = TokenRefreshSerializer(data={"refresh": str(refresh)})
+
+        with self.assertRaises(django_exceptions.ObjectDoesNotExist) as e:
+            s.is_valid()
+
+        self.assertIn("does not exist", str(e.exception))
+
 
     def test_it_should_raise_error_for_inactive_users(self):
         refresh = RefreshToken.for_user(self.user)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -247,6 +247,43 @@ class TestTokenRefreshSlidingSerializer(TestCase):
 
 
 class TestTokenRefreshSerializer(TestCase):
+    def setUp(self):
+        self.username = "test_user"
+        self.password = "test_password"
+
+        self.user = User.objects.create_user(
+            username=self.username,
+            password=self.password,
+        )
+
+    def test_it_should_raise_error_for_inactive_users(self):
+        refresh = RefreshToken.for_user(self.user)
+        self.user.is_active = False
+        self.user.save()
+
+        s = TokenRefreshSerializer(data={"refresh": str(refresh)})
+        
+        with self.assertRaises(drf_exceptions.AuthenticationFailed) as e:
+            s.is_valid()
+
+        self.assertIn("No active account", e.exception.args[0])
+
+    def test_it_should_return_access_token_for_active_users(self):
+        refresh = RefreshToken.for_user(self.user)
+
+        s = TokenRefreshSerializer(data={"refresh": str(refresh)})
+
+        now = aware_utcnow() - api_settings.ACCESS_TOKEN_LIFETIME / 2
+        with patch("rest_framework_simplejwt.tokens.aware_utcnow") as fake_aware_utcnow:
+            fake_aware_utcnow.return_value = now
+            s.is_valid()
+
+        access = AccessToken(s.validated_data["access"])
+
+        self.assertEqual(
+            access["exp"], datetime_to_epoch(now + api_settings.ACCESS_TOKEN_LIFETIME)
+        )
+
     def test_it_should_raise_token_error_if_token_invalid(self):
         token = RefreshToken()
         del token["exp"]

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -262,7 +262,7 @@ class TestTokenRefreshSerializer(TestCase):
         self.user.save()
 
         s = TokenRefreshSerializer(data={"refresh": str(refresh)})
-        
+
         with self.assertRaises(drf_exceptions.AuthenticationFailed) as e:
             s.is_valid()
 


### PR DESCRIPTION
Issue Description:
A refresh token generated for a previously active user was allowed to issue new access token although the user is inactive.

Fix:
Added a check to verify if the user claim in refresh token corresponds to an active user.

## Related issues
- https://github.com/jazzband/djangorestframework-simplejwt/issues/812