### PR TITLE
Use class property to set token classes instead of hardcoded taking it from global settings

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -33,6 +33,8 @@ class JWTAuthentication(authentication.BaseAuthentication):
     www_authenticate_realm = "api"
     media_type = "application/json"
 
+    access_token_classes = api_settings.AUTH_TOKEN_CLASSES
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.user_model = get_user_model()
@@ -98,7 +100,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
         wrapper object.
         """
         messages = []
-        for AuthToken in api_settings.AUTH_TOKEN_CLASSES:
+        for AuthToken in self.access_token_classes:
             try:
                 return AuthToken(raw_token)
             except TokenError as e:


### PR DESCRIPTION
I'm subclassing `JWTAuthentication` in order to work with custom token classes. This currently requires to overwrite and duplicate the entire `get_validated_token()` method because it hardcodes there the list of access tokens it checks. I don't want to change the implementation of the method but just use my own list of tokens. So I've moved this list to be an attribute of the class, so subclassing becomes easier without the need to override the method.