### PR TITLE
fix: Add support for EdDSA and other algorithms in jwt.algorithms.requires_cryptography (#822)

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -28,7 +28,7 @@ ALLOWED_ALGORITHMS = {
     "ES256",
     "ES384",
     "ES512",
-}
+}.union(algorithms.requires_cryptography)
 
 
 class TokenBackend:


### PR DESCRIPTION
Related issue: #822 

I have extended the list of `ALLOWED_ALGORITHMS` to include a few missing algorithms like `{'ES256K', 'ES521', 'EdDSA', 'PS256', 'PS384', 'PS512'}`