### PR TITLE
Add specific "token expired" exceptions

### DIFF
--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -8,6 +8,10 @@ class TokenError(Exception):
     pass
 
 
+class ExpiredTokenError(TokenError):
+    pass
+
+
 class TokenBackendError(Exception):
     pass
 

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -12,6 +12,10 @@ class TokenBackendError(Exception):
     pass
 
 
+class TokenBackendExpiredToken(TokenBackendError):
+    pass
+
+
 class DetailDictMixin:
     default_detail: str
     default_code: str

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -14,7 +14,10 @@ from jwt import __version__ as jwt_version
 from jwt import algorithms
 
 from rest_framework_simplejwt.backends import JWK_CLIENT_AVAILABLE, TokenBackend
-from rest_framework_simplejwt.exceptions import TokenBackendError
+from rest_framework_simplejwt.exceptions import (
+    TokenBackendError,
+    TokenBackendExpiredToken,
+)
 from rest_framework_simplejwt.utils import aware_utcnow, datetime_to_epoch, make_utc
 from tests.keys import (
     ES256_PRIVATE_KEY,
@@ -191,7 +194,7 @@ class TestTokenBackend(TestCase):
                     self.payload, backend.signing_key, algorithm=backend.algorithm
                 )
 
-                with self.assertRaises(TokenBackendError):
+                with self.assertRaises(TokenBackendExpiredToken):
                     backend.decode(expired_token)
 
     def test_decode_with_invalid_sig(self):
@@ -346,9 +349,7 @@ class TestTokenBackend(TestCase):
                 "RS256", PRIVATE_KEY, PUBLIC_KEY, AUDIENCE, ISSUER, JWK_URL
             )
 
-            with self.assertRaisesRegex(
-                TokenBackendError, "Token is invalid or expired"
-            ):
+            with self.assertRaisesRegex(TokenBackendError, "Token is invalid"):
                 jwk_token_backend.decode(token)
 
     def test_decode_when_algorithm_not_available(self):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -183,7 +183,7 @@ class TestTokenRefreshSlidingSerializer(TestCase):
         with self.assertRaises(TokenError) as e:
             s.is_valid()
 
-        self.assertIn("invalid or expired", e.exception.args[0])
+        self.assertIn("expired", e.exception.args[0])
 
     def test_it_should_raise_token_error_if_token_has_no_refresh_exp_claim(self):
         token = SlidingToken()
@@ -314,7 +314,7 @@ class TestTokenRefreshSerializer(TestCase):
         with self.assertRaises(TokenError) as e:
             s.is_valid()
 
-        self.assertIn("invalid or expired", e.exception.args[0])
+        self.assertIn("expired", e.exception.args[0])
 
     def test_it_should_raise_token_error_if_token_has_wrong_type(self):
         token = RefreshToken()
@@ -480,7 +480,7 @@ class TestTokenVerifySerializer(TestCase):
         with self.assertRaises(TokenError) as e:
             s.is_valid()
 
-        self.assertIn("invalid or expired", e.exception.args[0])
+        self.assertIn("expired", e.exception.args[0])
 
     def test_it_should_not_raise_token_error_if_token_has_wrong_type(self):
         token = RefreshToken()
@@ -525,7 +525,7 @@ class TestTokenBlacklistSerializer(TestCase):
         with self.assertRaises(TokenError) as e:
             s.is_valid()
 
-        self.assertIn("invalid or expired", e.exception.args[0])
+        self.assertIn("expired", e.exception.args[0])
 
     def test_it_should_raise_token_error_if_token_has_wrong_type(self):
         token = RefreshToken()

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -6,7 +6,11 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from jose import jwt
 
-from rest_framework_simplejwt.exceptions import TokenBackendError, TokenError
+from rest_framework_simplejwt.exceptions import (
+    ExpiredTokenError,
+    TokenBackendError,
+    TokenError,
+)
 from rest_framework_simplejwt.settings import api_settings
 from rest_framework_simplejwt.state import token_backend
 from rest_framework_simplejwt.tokens import (
@@ -157,7 +161,7 @@ class TestToken(TestCase):
         t = MyToken()
         t.set_exp(lifetime=-timedelta(seconds=1))
 
-        with self.assertRaises(TokenError):
+        with self.assertRaises(ExpiredTokenError):
             MyToken(str(t))
 
     def test_init_no_type_token_given(self):


### PR DESCRIPTION
To make it possible for the layers above to handle expired tokens differently from invalid tokens (use different error codes or whatever), without resorting to doing  string-matching on the error message.