### PR TITLE
Don't validate subject claim for compatibility with PyJWT>=2.10

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -146,6 +146,7 @@ class TokenBackend:
                 options={
                     "verify_aud": self.audience is not None,
                     "verify_signature": verify,
+                    "verify_sub": False,
                 },
             )
         except InvalidAlgorithmError as ex:


### PR DESCRIPTION
This fixes #831

Since PyJWT starting from 2.10 forces "sub" JWT claim to be a string, but default Django User model has integer key and it's used as "sub" claim by default - this causes authentication failures with a valid token. To fix that we omit subject validation by specifying corresponding option in token decode invocation.