### PR TITLE
Fix user_id type mismatch when user claim is not pk

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Type, TypeVar
 from uuid import uuid4
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
@@ -266,12 +267,17 @@ class BlacklistMixin(Generic[T]):
             jti = self.payload[api_settings.JTI_CLAIM]
             exp = self.payload["exp"]
             user_id = self.payload.get(api_settings.USER_ID_CLAIM)
+            User = get_user_model()
+            try:
+                user = User.objects.get(**{api_settings.USER_ID_FIELD: user_id})
+            except User.DoesNotExist:
+                user = None
 
             # Ensure outstanding token exists with given jti
             token, _ = OutstandingToken.objects.get_or_create(
                 jti=jti,
                 defaults={
-                    "user_id": user_id,
+                    "user": user,
                     "created_at": self.current_time,
                     "token": str(self),
                     "expires_at": datetime_from_epoch(exp),

--- a/tests/test_token_blacklist.py
+++ b/tests/test_token_blacklist.py
@@ -6,6 +6,7 @@ from django.core.management import call_command
 from django.db.models import BigAutoField
 from django.test import TestCase
 from django.utils import timezone
+
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.serializers import TokenVerifySerializer
 from rest_framework_simplejwt.settings import api_settings
@@ -178,7 +179,6 @@ class TestTokenBlacklist(TestCase):
         token.blacklist()
         outstanding_token = OutstandingToken.objects.get(token=token)
         self.assertEqual(outstanding_token.user, self.user)
-
 
     @override_api_settings(USER_ID_FIELD="email", USER_ID_CLAIM="email")
     def test_outstanding_token_with_deleted_user_and_modifed_user_id_field(self):


### PR DESCRIPTION
Regarding changes made at https://github.com/jazzband/djangorestframework-simplejwt/pull/806/files

We're using a USER_ID_CLAIM that is neither the primary key field nor is it the
same type as the primary key, (tests are using the email column but we use a
UUID column secondary key) and these previous changes fail at this point when
attempting to create an OutstandingToken, because it assumes that the ID pulled
out of the token claims is usable as the database key for a user.

So to mitigate this gets the user from the database using the USER_ID_FIELD
setting and uses that in the get_or_create call.