### PR TITLE
fix: use USER_ID_FIELD instead of user_id when get_or_create outstanding

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -266,12 +266,13 @@ class BlacklistMixin(Generic[T]):
             jti = self.payload[api_settings.JTI_CLAIM]
             exp = self.payload["exp"]
             user_id = self.payload.get(api_settings.USER_ID_CLAIM)
+            user_id_field = {api_settings.USER_ID_FIELD: user_id}
 
             # Ensure outstanding token exists with given jti
             token, _ = OutstandingToken.objects.get_or_create(
                 jti=jti,
                 defaults={
-                    "user_id": user_id,
+                    **user_id_field,
                     "created_at": self.current_time,
                     "token": str(self),
                     "expires_at": datetime_from_epoch(exp),


### PR DESCRIPTION
Fixes this [PR](https://github.com/jazzband/djangorestframework-simplejwt/pull/806/files)