### PR TITLE
Move Pyupgrade to python version 3.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
   rev: 'v3.15.0'
   hooks:
   - id: pyupgrade
-    args: ['--py38-plus', '--keep-mock']
+    args: ['--py39-plus', '--keep-mock']
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
   rev: v1.0.1

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -17,7 +17,7 @@ AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
 if not isinstance(api_settings.AUTH_HEADER_TYPES, (list, tuple)):
     AUTH_HEADER_TYPES = (AUTH_HEADER_TYPES,)
 
-AUTH_HEADER_TYPE_BYTES: Set[bytes] = {
+AUTH_HEADER_TYPE_BYTES: set[bytes] = {
     h.encode(HTTP_HEADER_ENCODING) for h in AUTH_HEADER_TYPES
 }
 
@@ -37,7 +37,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
         super().__init__(*args, **kwargs)
         self.user_model = get_user_model()
 
-    def authenticate(self, request: Request) -> Optional[Tuple[AuthUser, Token]]:
+    def authenticate(self, request: Request) -> Optional[tuple[AuthUser, Token]]:
         header = self.get_header(request)
         if header is None:
             return None

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -1,4 +1,4 @@
-from typing import Optional, Set, Tuple, TypeVar
+from typing import Optional, TypeVar
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -46,7 +46,7 @@ class TokenBackend:
         issuer: Optional[str] = None,
         jwk_url: Optional[str] = None,
         leeway: Union[float, int, timedelta, None] = None,
-        json_encoder: Optional[Type[json.JSONEncoder]] = None,
+        json_encoder: Optional[type[json.JSONEncoder]] = None,
     ) -> None:
         self._validate_algorithm(algorithm)
 
@@ -110,7 +110,7 @@ class TokenBackend:
 
         return self.verifying_key
 
-    def encode(self, payload: Dict[str, Any]) -> str:
+    def encode(self, payload: dict[str, Any]) -> str:
         """
         Returns an encoded token for the given payload dictionary.
         """
@@ -132,7 +132,7 @@ class TokenBackend:
         # For PyJWT >= 2.0.0a1
         return token
 
-    def decode(self, token: Token, verify: bool = True) -> Dict[str, Any]:
+    def decode(self, token: Token, verify: bool = True) -> dict[str, Any]:
         """
         Performs a validation of the given token and returns its payload
         dictionary.

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterable
 from datetime import timedelta
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import jwt
 from django.utils.translation import gettext_lazy as _

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -26,7 +26,7 @@ class DetailDictMixin:
 
     def __init__(
         self,
-        detail: Union[Dict[str, Any], str, None] = None,
+        detail: Union[dict[str, Any], str, None] = None,
         code: Optional[str] = None,
     ) -> None:
         """

--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status

--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -93,7 +93,7 @@ class TokenUser:
     def has_perm(self, perm: str, obj: Optional[object] = None) -> bool:
         return False
 
-    def has_perms(self, perm_list: List[str], obj: Optional[object] = None) -> bool:
+    def has_perms(self, perm_list: list[str], obj: Optional[object] = None) -> bool:
         return False
 
     def has_module_perms(self, module: str) -> bool:

--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from django.contrib.auth import models as auth_models
 from django.db.models.manager import EmptyManager

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -29,7 +29,7 @@ class PasswordField(serializers.CharField):
 
 class TokenObtainSerializer(serializers.Serializer):
     username_field = get_user_model().USERNAME_FIELD
-    token_class: Optional[Type[Token]] = None
+    token_class: Optional[type[Token]] = None
 
     default_error_messages = {
         "no_active_account": _("No active account found with the given credentials")
@@ -41,7 +41,7 @@ class TokenObtainSerializer(serializers.Serializer):
         self.fields[self.username_field] = serializers.CharField(write_only=True)
         self.fields["password"] = PasswordField()
 
-    def validate(self, attrs: Dict[str, Any]) -> Dict[Any, Any]:
+    def validate(self, attrs: dict[str, Any]) -> dict[Any, Any]:
         authenticate_kwargs = {
             self.username_field: attrs[self.username_field],
             "password": attrs["password"],
@@ -69,7 +69,7 @@ class TokenObtainSerializer(serializers.Serializer):
 class TokenObtainPairSerializer(TokenObtainSerializer):
     token_class = RefreshToken
 
-    def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
+    def validate(self, attrs: dict[str, Any]) -> dict[str, str]:
         data = super().validate(attrs)
 
         refresh = self.get_token(self.user)
@@ -86,7 +86,7 @@ class TokenObtainPairSerializer(TokenObtainSerializer):
 class TokenObtainSlidingSerializer(TokenObtainSerializer):
     token_class = SlidingToken
 
-    def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
+    def validate(self, attrs: dict[str, Any]) -> dict[str, str]:
         data = super().validate(attrs)
 
         token = self.get_token(self.user)
@@ -108,7 +108,7 @@ class TokenRefreshSerializer(serializers.Serializer):
         "no_active_account": _("No active account found for the given token.")
     }
 
-    def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
+    def validate(self, attrs: dict[str, Any]) -> dict[str, str]:
         refresh = self.token_class(attrs["refresh"])
 
         user_id = refresh.payload.get(api_settings.USER_ID_CLAIM, None)
@@ -148,7 +148,7 @@ class TokenRefreshSlidingSerializer(serializers.Serializer):
     token = serializers.CharField()
     token_class = SlidingToken
 
-    def validate(self, attrs: Dict[str, Any]) -> Dict[str, str]:
+    def validate(self, attrs: dict[str, Any]) -> dict[str, str]:
         token = self.token_class(attrs["token"])
 
         # Check that the timestamp in the "refresh_exp" claim has not
@@ -165,7 +165,7 @@ class TokenRefreshSlidingSerializer(serializers.Serializer):
 class TokenVerifySerializer(serializers.Serializer):
     token = serializers.CharField(write_only=True)
 
-    def validate(self, attrs: Dict[str, None]) -> Dict[Any, Any]:
+    def validate(self, attrs: dict[str, None]) -> dict[Any, Any]:
         token = UntypedToken(attrs["token"])
 
         if (
@@ -183,7 +183,7 @@ class TokenBlacklistSerializer(serializers.Serializer):
     refresh = serializers.CharField(write_only=True)
     token_class = RefreshToken
 
-    def validate(self, attrs: Dict[str, Any]) -> Dict[Any, Any]:
+    def validate(self, attrs: dict[str, Any]) -> dict[Any, Any]:
         refresh = self.token_class(attrs["refresh"])
         try:
             refresh.blacklist()

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type, TypeVar
+from typing import Any, Optional, TypeVar
 
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -63,7 +63,7 @@ REMOVED_SETTINGS = (
 
 
 class APISettings(_APISettings):  # pragma: no cover
-    def __check_user_settings(self, user_settings: Dict[str, Any]) -> Dict[str, Any]:
+    def __check_user_settings(self, user_settings: dict[str, Any]) -> dict[str, Any]:
         SETTINGS_DOC = "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
 
         for setting in REMOVED_SETTINGS:

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Dict
+from typing import Any
 
 from django.conf import settings
 from django.test.signals import setting_changed

--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -34,7 +34,7 @@ class OutstandingTokenAdmin(admin.ModelAdmin):
     # Read-only behavior defined below
     actions = None
 
-    def get_readonly_fields(self, *args, **kwargs) -> List[Any]:
+    def get_readonly_fields(self, *args, **kwargs) -> list[Any]:
         return [f.name for f in self.model._meta.fields]
 
     def has_add_permission(self, *args, **kwargs) -> bool:

--- a/rest_framework_simplejwt/token_blacklist/admin.py
+++ b/rest_framework_simplejwt/token_blacklist/admin.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, List, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 from django.contrib import admin
 from django.contrib.auth.models import AbstractBaseUser

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 from uuid import uuid4
 
 from django.conf import settings

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -204,7 +204,7 @@ class Token:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
 
     @classmethod
-    def for_user(cls: Type[T], user: AuthUser) -> T:
+    def for_user(cls: type[T], user: AuthUser) -> T:
         """
         Returns an authorization token for the given user that will be provided
         after authenticating the user's credentials.
@@ -246,7 +246,7 @@ class BlacklistMixin(Generic[T]):
     membership in a token blacklist.
     """
 
-    payload: Dict[str, Any]
+    payload: dict[str, Any]
 
     if "rest_framework_simplejwt.token_blacklist" in settings.INSTALLED_APPS:
 
@@ -288,7 +288,7 @@ class BlacklistMixin(Generic[T]):
             return BlacklistedToken.objects.get_or_create(token=token)
 
         @classmethod
-        def for_user(cls: Type[T], user: AuthUser) -> T:
+        def for_user(cls: type[T], user: AuthUser) -> T:
             """
             Adds this token to the outstanding token list.
             """


### PR DESCRIPTION
With the new version out, the support for Python 3.8 has been officially dropped (even though unofficially it should still work). 

This PR:
- updates pyupgrade library to upgrade the syntax to match Python 3.9 version (minimal official supported version in this project), 
- runs pyupgrade with `--py39-plus` option to update the syntax across the whole codebase 