### PR TITLE
chore: clean redefinition of mock_jwk_module in backend tests

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -302,7 +302,6 @@ class TestTokenBackend(TestCase):
         # Payload copied
         self.payload["exp"] = datetime_to_epoch(self.payload["exp"])
 
-        mock_jwk_module = mock.MagicMock()
         with patch("rest_framework_simplejwt.backends.PyJWKClient") as mock_jwk_module:
             mock_jwk_client = mock.MagicMock()
             mock_signing_key = mock.MagicMock()
@@ -335,7 +334,6 @@ class TestTokenBackend(TestCase):
             headers={"kid": "230498151c214b788dd97f22b85410a5"},
         )
 
-        mock_jwk_module = mock.MagicMock()
         with patch("rest_framework_simplejwt.backends.PyJWKClient") as mock_jwk_module:
             mock_jwk_client = mock.MagicMock()
 


### PR DESCRIPTION
In `tests/test_backends.py` `mock_jwk_module` is defined twice, but the first definition is never used.

This is a preparation PR to add a linter to the pre-commit, since it would catch a lot of similar stuff.

I have run locally `ruff` to detect all the linting problems, this is the only thing worth fixing that was found.