### PR TITLE
Add ruff linter and formatter to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,61 +1,61 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.5.0"
-    hooks:
-      - id: check-merge-conflict
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
-    hooks:
-      - id: ruff
-        types_or: [python, pyi]
-        args: [--select, I, --fix]
-        files: "^tests/|^rest_framework_simplejwt/"
-      - id: ruff-format
-        types_or: [python, pyi]
-        files: "^tests/|^rest_framework_simplejwt/"
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
-    hooks:
-      - id: yesqa
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.5.0"
-    hooks:
-      - id: end-of-file-fixer
-        exclude: >-
-          ^docs/[^/]*\.svg$
-      - id: requirements-txt-fixer
-      - id: trailing-whitespace
-        types: [python]
-      - id: file-contents-sorter
-        files: |
-          CONTRIBUTORS.txt|
-          docs/spelling_wordlist.txt|
-          .gitignore|
-          .gitattributes
-      - id: check-case-conflict
-      - id: check-json
-      - id: check-xml
-      - id: check-executables-have-shebangs
-      - id: check-toml
-      - id: check-xml
-      - id: check-yaml
-      - id: debug-statements
-      - id: check-added-large-files
-      - id: check-symlinks
-      - id: debug-statements
-      - id: detect-aws-credentials
-        args: ["--allow-missing-credentials"]
-      - id: detect-private-key
-        exclude: ^tests/
-  - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.15.0"
-    hooks:
-      - id: pyupgrade
-        args: ["--py39-plus", "--keep-mock"]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 'v4.5.0'
+  hooks:
+  - id: check-merge-conflict
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.1
+  hooks:
+  - id: ruff
+    types_or: [ python, pyi ]
+    args: [--select, I, --fix,]
+    files: "^tests/|^rest_framework_simplejwt/"
+  - id: ruff-format
+    types_or: [python, pyi]
+    files: "^tests/|^rest_framework_simplejwt/"
+- repo: https://github.com/asottile/yesqa
+  rev: v1.5.0
+  hooks:
+  - id: yesqa
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 'v4.5.0'
+  hooks:
+  - id: end-of-file-fixer
+    exclude: >-
+      ^docs/[^/]*\.svg$
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace
+    types: [python]
+  - id: file-contents-sorter
+    files: |
+      CONTRIBUTORS.txt|
+      docs/spelling_wordlist.txt|
+      .gitignore|
+      .gitattributes
+  - id: check-case-conflict
+  - id: check-json
+  - id: check-xml
+  - id: check-executables-have-shebangs
+  - id: check-toml
+  - id: check-xml
+  - id: check-yaml
+  - id: debug-statements
+  - id: check-added-large-files
+  - id: check-symlinks
+  - id: debug-statements
+  - id: detect-aws-credentials
+    args: ['--allow-missing-credentials']
+  - id: detect-private-key
+    exclude: ^tests/
+- repo: https://github.com/asottile/pyupgrade
+  rev: 'v3.15.0'
+  hooks:
+  - id: pyupgrade
+    args: ['--py39-plus', '--keep-mock']
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
-    rev: v1.0.1
-    hooks:
-      - id: rst-linter
-        files: >-
-          ^[^/]+[.]rst$
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
+  rev: v1.0.1
+  hooks:
+  - id: rst-linter
+    files: >-
+      ^[^/]+[.]rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,68 +1,61 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.5.0'
-  hooks:
-  - id: check-merge-conflict
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.1
-  hooks:
-  - id: ruff
-    types_or: [ python, pyi ]
-    args: [--fix]
-    files: "^tests/|^rest_framework_simplejwt/"
-- repo: https://github.com/asottile/yesqa
-  rev: v1.5.0
-  hooks:
-  - id: yesqa
-- repo: https://github.com/pycqa/isort
-  rev: '5.12.0'
-  hooks:
-  - id: isort
-    args: ["--profile", "black"]
-- repo: https://github.com/psf/black
-  rev: '23.11.0'
-  hooks:
-  - id: black
-    language_version: python3 # Should be a command that runs python3.6+
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.5.0'
-  hooks:
-  - id: end-of-file-fixer
-    exclude: >-
-      ^docs/[^/]*\.svg$
-  - id: requirements-txt-fixer
-  - id: trailing-whitespace
-    types: [python]
-  - id: file-contents-sorter
-    files: |
-      CONTRIBUTORS.txt|
-      docs/spelling_wordlist.txt|
-      .gitignore|
-      .gitattributes
-  - id: check-case-conflict
-  - id: check-json
-  - id: check-xml
-  - id: check-executables-have-shebangs
-  - id: check-toml
-  - id: check-xml
-  - id: check-yaml
-  - id: debug-statements
-  - id: check-added-large-files
-  - id: check-symlinks
-  - id: debug-statements
-  - id: detect-aws-credentials
-    args: ['--allow-missing-credentials']
-  - id: detect-private-key
-    exclude: ^tests/
-- repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.15.0'
-  hooks:
-  - id: pyupgrade
-    args: ['--py39-plus', '--keep-mock']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.5.0"
+    hooks:
+      - id: check-merge-conflict
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.1
+    hooks:
+      - id: ruff
+        types_or: [python, pyi]
+        args: [--select, I, --fix]
+        files: "^tests/|^rest_framework_simplejwt/"
+      - id: ruff-format
+        types_or: [python, pyi]
+        files: "^tests/|^rest_framework_simplejwt/"
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.5.0
+    hooks:
+      - id: yesqa
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v4.5.0"
+    hooks:
+      - id: end-of-file-fixer
+        exclude: >-
+          ^docs/[^/]*\.svg$
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+        types: [python]
+      - id: file-contents-sorter
+        files: |
+          CONTRIBUTORS.txt|
+          docs/spelling_wordlist.txt|
+          .gitignore|
+          .gitattributes
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-xml
+      - id: check-executables-have-shebangs
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: check-added-large-files
+      - id: check-symlinks
+      - id: debug-statements
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
+      - id: detect-private-key
+        exclude: ^tests/
+  - repo: https://github.com/asottile/pyupgrade
+    rev: "v3.15.0"
+    hooks:
+      - id: pyupgrade
+        args: ["--py39-plus", "--keep-mock"]
 
-- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
-  rev: v1.0.1
-  hooks:
-  - id: rst-linter
-    files: >-
-      ^[^/]+[.]rst$
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
+    rev: v1.0.1
+    hooks:
+      - id: rst-linter
+        files: >-
+          ^[^/]+[.]rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,13 @@ repos:
   rev: 'v4.5.0'
   hooks:
   - id: check-merge-conflict
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.1
+  hooks:
+  - id: ruff
+    types_or: [ python, pyi ]
+    args: [--fix]
+    files: "^tests/|^rest_framework_simplejwt/"
 - repo: https://github.com/asottile/yesqa
   rev: v1.5.0
   hooks:

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,6 @@ extras_require = {
     ],
     "lint": [
         "ruff",
-        "isort",
-        "black",
         "yesqa",
         "pyupgrade",
         "pre-commit",

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,12 @@ extras_require = {
         "tox",
     ],
     "lint": [
-        "flake8",
-        "pep8",
+        "ruff",
         "isort",
+        "black",
+        "yesqa",
+        "pyupgrade",
+        "pre-commit",
     ],
     "doc": [
         "Sphinx>=1.6.5,<2",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,9 +9,8 @@ from unittest.mock import patch
 import jwt
 import pytest
 from django.test import TestCase
-from jwt import PyJWS
+from jwt import PyJWS, algorithms
 from jwt import __version__ as jwt_version
-from jwt import algorithms
 
 from rest_framework_simplejwt.backends import JWK_CLIENT_AVAILABLE, TokenBackend
 from rest_framework_simplejwt.exceptions import (


### PR DESCRIPTION
In the past 2 PRs that i have opened, i have used linter locally to double check the changes and that i haven't forgotten something. I thing all of the devs (of this library) would benefit from having the linter as a part of `pre-commit` hooks to quickly get the feedback about potential problems in code :) 

I have no hard opinions about this specific linter or formatter, but `ruff` is fast, and it is very easy to setup. I have been using `ruff` in a few of my personal projects and i really like it, so i have opened a PR to add it to this repo too.

In addition to adding the new linter and formatter, I have also updated `extras_require` in `setup.py` since it contained unused packages, and it didn't list all of the packages that are being actively used.