### PR TITLE
Caching signing key

### DIFF
--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -73,7 +73,7 @@ class TokenBackend:
     def prepared_verifying_key(self) -> Any:
         return self._prepare_key(self.verifying_key)
 
-    def _prepare_key(self, key: str | None) -> Any:
+    def _prepare_key(self, key: Optional[str]) -> Any:
         # Support for PyJWT 1.7.1 or empty signing key
         if key is None or not getattr(jwt.PyJWS, "get_algorithm_by_name", None):
             return key

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -67,6 +67,8 @@ class TokenBackend:
 
     @cached_property
     def signing_key(self) -> Any:
+        if self.raw_signing_key is None:
+            return None
         jws_alg = jwt.PyJWS().get_algorithm_by_name(self.algorithm)
         return jws_alg.prepare_key(self.raw_signing_key)
 

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -67,8 +67,11 @@ class TokenBackend:
 
     @cached_property
     def signing_key(self) -> Any:
-        if self.raw_signing_key is None:
-            return None
+        # Support for PyJWT 1.7.1 or empty signing key
+        if self.raw_signing_key is None or not getattr(
+            jwt.PyJWS, "get_algorithm_by_name", None
+        ):
+            return self.raw_signing_key
         jws_alg = jwt.PyJWS().get_algorithm_by_name(self.algorithm)
         return jws_alg.prepare_key(self.raw_signing_key)
 

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -1,7 +1,7 @@
-from functools import cached_property
 import json
 from collections.abc import Iterable
 from datetime import timedelta
+from functools import cached_property
 from typing import Any, Optional, Union
 
 import jwt
@@ -64,7 +64,7 @@ class TokenBackend:
 
         self.leeway = leeway
         self.json_encoder = json_encoder
-        
+
     @cached_property
     def signing_key(self) -> Any:
         jws_alg = jwt.PyJWS().get_algorithm_by_name(self.algorithm)

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import json
 from collections.abc import Iterable
 from datetime import timedelta
@@ -51,7 +52,7 @@ class TokenBackend:
         self._validate_algorithm(algorithm)
 
         self.algorithm = algorithm
-        self.signing_key = signing_key
+        self.raw_signing_key = signing_key
         self.verifying_key = verifying_key
         self.audience = audience
         self.issuer = issuer
@@ -63,6 +64,11 @@ class TokenBackend:
 
         self.leeway = leeway
         self.json_encoder = json_encoder
+        
+    @cached_property
+    def signing_key(self) -> Any:
+        jws_alg = jwt.PyJWS().get_algorithm_by_name(self.algorithm)
+        return jws_alg.prepare_key(self.raw_signing_key)
 
     def _validate_algorithm(self, algorithm: str) -> None:
         """


### PR DESCRIPTION
Hi! Recently, we noticed significantly slow creation of access and refresh tokens (RSA256) in our project. After investigating, I found that there was no caching for the signing key, which was affecting the token generation speed, especially in CPU-limited environments (source: https://pyjwt.readthedocs.io/en/stable/usage.html#encoding-decoding-tokens-with-rs256-rsa). Implementing this quick fix improved token generation performance by 15x for us.

All tests passed successfully, except for one old test for PyJWT support. This test checks the type of the signing key and expects it to be a string, but I’m not sure if the older version of PyJWT is still relevant. What do you think?