### PR TITLE
Adds new refresh tokens to OutstandingToken db.

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -138,6 +138,7 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()
+            refresh.outstand()
 
             data["refresh"] = str(refresh)
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -203,6 +203,31 @@ class Token:
         leeway = self.get_token_backend().get_leeway()
         if claim_time <= current_time - leeway:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
+    
+    def outstand(self) -> OutstandingToken:
+        """
+        Ensures this token is included in the outstanding token list and
+        adds it to the outstanding token list if not.
+        """
+        jti = self.payload[api_settings.JTI_CLAIM]
+        exp = self.payload["exp"]
+        user_id = self.payload.get(api_settings.USER_ID_CLAIM)
+        User = get_user_model()
+        try:
+            user = User.objects.get(**{api_settings.USER_ID_FIELD: user_id})
+        except User.DoesNotExist:
+            user = None
+
+        # Ensure outstanding token exists with given jti
+        return OutstandingToken.objects.get_or_create(
+            jti=jti,
+            defaults={
+                "user": user,
+                "created_at": self.current_time,
+                "token": str(self),
+                "expires_at": datetime_from_epoch(exp),
+            },
+        )
 
     @classmethod
     def for_user(cls: type[T], user: AuthUser) -> T:

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -203,7 +203,7 @@ class Token:
         leeway = self.get_token_backend().get_leeway()
         if claim_time <= current_time - leeway:
             raise TokenError(format_lazy(_("Token '{}' claim has expired"), claim))
-    
+
     def outstand(self) -> OutstandingToken:
         """
         Ensures this token is included in the outstanding token list and

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -451,7 +451,7 @@ class TestTokenRefreshSerializer(TestCase):
             datetime_to_epoch(now + api_settings.REFRESH_TOKEN_LIFETIME),
         )
 
-        self.assertEqual(OutstandingToken.objects.count(), 1)
+        self.assertEqual(OutstandingToken.objects.count(), 2)
         self.assertEqual(BlacklistedToken.objects.count(), 1)
 
         # Assert old refresh token is blacklisted


### PR DESCRIPTION
Fixes the issue #363 where new refresh tokens issued out do not get added to the OutstandingToken db.

The issue was resolved by adding a method to the `Token` class called `outstand`, which checks if the token is in the outstanding table, and adds it if not.

When `ROTATE_REFRESH_TOKENS` is set to `True`, the `TokenRefreshSerializer` calls the `.outstand()` method on the new refresh token that is issued.

All tests ran fine, except for test `test_it_should_blacklist_refresh_token_if_tokens_should_be_rotated_and_blacklisted`. The reason for this was it was asserting that outstanding table has `1` token.

However, since this bug is now fixed, there should be in fact `2` tokens in the outstanding table. One for the initial refresh token issued during authentication, and the second token which is issued during a refresh, which was implemented in this PR with `.outstand()`. So I have changed that test to assert two tokens in the table, which is now correct.