### PR TITLE
ref: full tracebacks on exceptions

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -123,13 +123,17 @@ class JWTAuthentication(authentication.BaseAuthentication):
         """
         try:
             user_id = validated_token[api_settings.USER_ID_CLAIM]
-        except KeyError:
-            raise InvalidToken(_("Token contained no recognizable user identification"))
+        except KeyError as e:
+            raise InvalidToken(
+                _("Token contained no recognizable user identification")
+            ) from e
 
         try:
             user = self.user_model.objects.get(**{api_settings.USER_ID_FIELD: user_id})
-        except self.user_model.DoesNotExist:
-            raise AuthenticationFailed(_("User not found"), code="user_not_found")
+        except self.user_model.DoesNotExist as e:
+            raise AuthenticationFailed(
+                _("User not found"), code="user_not_found"
+            ) from e
 
         if api_settings.CHECK_USER_IS_ACTIVE and not user.is_active:
             raise AuthenticationFailed(_("User is inactive"), code="user_inactive")

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -121,8 +121,8 @@ class TokenBackend:
         if self.jwks_client:
             try:
                 return self.jwks_client.get_signing_key_from_jwt(token).key
-            except PyJWKClientError as ex:
-                raise TokenBackendError(_("Token is invalid")) from ex
+            except PyJWKClientError as e:
+                raise TokenBackendError(_("Token is invalid")) from e
 
         return self.prepared_verifying_key
 
@@ -169,9 +169,9 @@ class TokenBackend:
                     "verify_signature": verify,
                 },
             )
-        except InvalidAlgorithmError as ex:
-            raise TokenBackendError(_("Invalid algorithm specified")) from ex
-        except ExpiredSignatureError as ex:
-            raise TokenBackendExpiredToken(_("Token is expired")) from ex
-        except InvalidTokenError as ex:
-            raise TokenBackendError(_("Token is invalid")) from ex
+        except InvalidAlgorithmError as e:
+            raise TokenBackendError(_("Invalid algorithm specified")) from e
+        except ExpiredSignatureError as e:
+            raise TokenBackendExpiredToken(_("Token is expired")) from e
+        except InvalidTokenError as e:
+            raise TokenBackendError(_("Token is invalid")) from e

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -62,10 +62,10 @@ class Token:
             # Decode token
             try:
                 self.payload = token_backend.decode(token, verify=verify)
-            except TokenBackendExpiredToken:
-                raise ExpiredTokenError(_("Token is expired"))
-            except TokenBackendError:
-                raise TokenError(_("Token is invalid"))
+            except TokenBackendExpiredToken as e:
+                raise ExpiredTokenError(_("Token is expired")) from e
+            except TokenBackendError as e:
+                raise TokenError(_("Token is invalid")) from e
 
             if verify:
                 self.verify()
@@ -134,8 +134,8 @@ class Token:
         """
         try:
             token_type = self.payload[api_settings.TOKEN_TYPE_CLAIM]
-        except KeyError:
-            raise TokenError(_("Token has no type"))
+        except KeyError as e:
+            raise TokenError(_("Token has no type")) from e
 
         if self.token_type != token_type:
             raise TokenError(_("Token has wrong type"))
@@ -196,8 +196,8 @@ class Token:
 
         try:
             claim_value = self.payload[claim]
-        except KeyError:
-            raise TokenError(format_lazy(_("Token has no '{}' claim"), claim))
+        except KeyError as e:
+            raise TokenError(format_lazy(_("Token has no '{}' claim"), claim)) from e
 
         claim_time = datetime_from_epoch(claim_value)
         leeway = self.get_token_backend().get_leeway()

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -27,9 +27,9 @@ class TokenViewBase(generics.GenericAPIView):
             return self.serializer_class
         try:
             return import_string(self._serializer_class)
-        except ImportError:
+        except ImportError as e:
             msg = f"Could not import serializer '{self._serializer_class}'"
-            raise ImportError(msg)
+            raise ImportError(msg) from e
 
     def get_authenticate_header(self, request: Request) -> str:
         return '{} realm="{}"'.format(
@@ -43,7 +43,7 @@ class TokenViewBase(generics.GenericAPIView):
         try:
             serializer.is_valid(raise_exception=True)
         except TokenError as e:
-            raise InvalidToken(e.args[0])
+            raise InvalidToken(e.args[0]) from e
 
         return Response(serializer.validated_data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
To get full tracebacks for easier debugging, when exception is caught and re-raised it needs to be re-raised as: `raise Exception from e`.

This PR adjust this behavior across the whole code base, and introduces consistency.

Fixes https://github.com/jazzband/djangorestframework-simplejwt/issues/832