### PR TITLE
Repair the type annotations in the TokenViewBase class.

### DIFF
--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -1,3 +1,5 @@
+from typing import Optional, Type
+
 from django.utils.module_loading import import_string
 from rest_framework import generics, status
 from rest_framework.request import Request
@@ -13,12 +15,12 @@ class TokenViewBase(generics.GenericAPIView):
     permission_classes = ()
     authentication_classes = ()
 
-    serializer_class = None
+    serializer_class: Optional[Type[Serializer]] = None
     _serializer_class = ""
 
     www_authenticate_realm = "api"
 
-    def get_serializer_class(self) -> Serializer:
+    def get_serializer_class(self) -> Type[Serializer]:
         """
         If serializer_class is set, use it directly. Otherwise get the class from settings.
         """

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Optional
 
 from django.utils.module_loading import import_string
 from rest_framework import generics, status

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -15,12 +15,12 @@ class TokenViewBase(generics.GenericAPIView):
     permission_classes = ()
     authentication_classes = ()
 
-    serializer_class: Optional[Type[Serializer]] = None
+    serializer_class: Optional[type[Serializer]] = None
     _serializer_class = ""
 
     www_authenticate_realm = "api"
 
-    def get_serializer_class(self) -> Type[Serializer]:
+    def get_serializer_class(self) -> type[Serializer]:
         """
         If serializer_class is set, use it directly. Otherwise get the class from settings.
         """

--- a/rest_framework_simplejwt/views.py
+++ b/rest_framework_simplejwt/views.py
@@ -4,7 +4,7 @@ from django.utils.module_loading import import_string
 from rest_framework import generics, status
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.serializers import Serializer
+from rest_framework.serializers import BaseSerializer
 
 from .authentication import AUTH_HEADER_TYPES
 from .exceptions import InvalidToken, TokenError
@@ -15,12 +15,12 @@ class TokenViewBase(generics.GenericAPIView):
     permission_classes = ()
     authentication_classes = ()
 
-    serializer_class: Optional[type[Serializer]] = None
+    serializer_class: Optional[type[BaseSerializer]] = None
     _serializer_class = ""
 
     www_authenticate_realm = "api"
 
-    def get_serializer_class(self) -> type[Serializer]:
+    def get_serializer_class(self) -> type[BaseSerializer]:
         """
         If serializer_class is set, use it directly. Otherwise get the class from settings.
         """


### PR DESCRIPTION
When extending the `TokenViewBase` class in order to override the `serializer_class` property, the type of the property is already established as NoneType, causing type check errors.

This PR explicitly annotates `serializer_class` to be `Optional[Type[Serializer]]`, allowing for the default `None` and also any other class that is a child of `Serializer`.

Note also that the type of the return of `get_serializer_class()` was erroneously `Serializer` (an instance of `Serializer`), when it should be `Type[Serializer]` (a class who's type includes `Serializer`).

EDIT: Turned out BaseSerializer was the correct type, not Serializer.