### PR TITLE
Added fix for Attribute error when `ROTATE_REFRESH_TOKENS=True` and `blacklist` app is not installed.

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -130,6 +130,8 @@ class TokenRefreshSerializer(serializers.Serializer):
                 try:
                     # Attempt to blacklist the given refresh token
                     refresh.blacklist()
+                    # Outstand the token only if the `blacklist` app is installed
+                    refresh.outstand()
                 except AttributeError:
                     # If blacklist app not installed, `blacklist` method will
                     # not be present
@@ -138,7 +140,6 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()
-            refresh.outstand()
 
             data["refresh"] = str(refresh)
 


### PR DESCRIPTION
When the blacklist app is not installed, the Refresh Token endpoint fails with Attribute error.

Moving the outstand method inside the if block fixes the issue.