### PR TITLE
ref: introduce consistency in usage of `Token` and `BlacklistMixin` methods

### DIFF
--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -126,15 +126,7 @@ class TokenRefreshSerializer(serializers.Serializer):
         data = {"access": str(refresh.access_token)}
 
         if api_settings.ROTATE_REFRESH_TOKENS:
-            if api_settings.BLACKLIST_AFTER_ROTATION:
-                try:
-                    # Attempt to blacklist the given refresh token
-                    refresh.blacklist()
-                except AttributeError:
-                    # If blacklist app not installed, `blacklist` method will
-                    # not be present
-                    pass
-
+            refresh.blacklist()
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -212,6 +212,13 @@ class Token:
         """
         return None
 
+    def blacklist(self) -> Optional[BlacklistedToken]:
+        """
+        Ensures this token is included in the outstanding token list and
+        adds it to the outstanding token list if not.
+        """
+        return None
+
     @classmethod
     def for_user(cls: type[T], user: AuthUser) -> T:
         """
@@ -280,7 +287,7 @@ class BlacklistMixin(Generic[T]):
             if BlacklistedToken.objects.filter(token__jti=jti).exists():
                 raise TokenError(_("Token is blacklisted"))
 
-        def blacklist(self) -> BlacklistedToken:
+        def blacklist(self) -> Optional[BlacklistedToken]:
             """
             Ensures this token is included in the outstanding token list and
             adds it to the blacklist.


### PR DESCRIPTION
Inspired by https://github.com/jazzband/djangorestframework-simplejwt/pull/884, this introduces consistency in how we handle methods existing in both `Token` and `BlacklistMixin` token classes