### PR TITLE
fix: PytestConfigWarning Unknown config option: python_paths

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
+pythonpath= .
 xfail_strict=true
 
 [pytest-watch]


### PR DESCRIPTION
In pytest 7.0.0 this was changed, more details: https://github.com/pytest-dev/pytest/discussions/9635

Error I was seeing while running tests:
```bash
============================================================================= warnings summary =============================================================================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1441
  /djangorestframework-simplejwt/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1441: PytestConfigWarning: Unknown config option: python_paths
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```