### PR TITLE
fix: always stringify user_id claim

### DIFF
--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -34,11 +34,11 @@ class TokenUser:
         return f"TokenUser {self.id}"
 
     @cached_property
-    def id(self) -> Union[int, str]:
+    def id(self) -> str:
         return self.token[api_settings.USER_ID_CLAIM]
 
     @cached_property
-    def pk(self) -> Union[int, str]:
+    def pk(self) -> str:
         return self.id
 
     @cached_property

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -225,8 +225,7 @@ class Token:
             )
 
         user_id = getattr(user, api_settings.USER_ID_FIELD)
-        if not isinstance(user_id, int):
-            user_id = str(user_id)
+        user_id = str(user_id)
 
         token = cls()
         token[api_settings.USER_ID_CLAIM] = user_id

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         "django>=4.2",
         "djangorestframework>=3.14",
-        "pyjwt>=1.7.1,<2.10.0",
+        "pyjwt>=1.7.1",
     ],
     python_requires=">=3.9",
     extras_require=extras_require,

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -225,6 +225,17 @@ class TestJWTAuthentication(TestCase):
         # Otherwise, should return correct user
         self.assertEqual(self.backend.get_user(payload).id, u.id)
 
+    def test_get_user_with_str_user_id_claim(self):
+        """
+        Verify that even though the user id is an int, it can be verified
+        and retrieved if the user id claim value is a string
+        """
+
+        user = User.objects.create_user(username="testuser")
+        payload = {api_settings.USER_ID_CLAIM: str(user.id)}
+        auth_user = self.backend.get_user(payload)
+        self.assertEqual(auth_user.id, user.id)
+
 
 class TestJWTStatelessUserAuthentication(TestCase):
     def setUp(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,7 @@ AuthToken = api_settings.AUTH_TOKEN_CLASSES[0]
 class TestTokenUser(TestCase):
     def setUp(self):
         self.token = AuthToken()
-        self.token[api_settings.USER_ID_CLAIM] = 42
+        self.token[api_settings.USER_ID_CLAIM] = "42"
         self.token["username"] = "deep-thought"
         self.token["some_other_stuff"] = "arstarst"
 
@@ -40,13 +40,13 @@ class TestTokenUser(TestCase):
         self.assertEqual(str(self.user), "TokenUser 42")
 
     def test_id(self):
-        self.assertEqual(self.user.id, 42)
+        self.assertEqual(self.user.id, "42")
 
     def test_pk(self):
-        self.assertEqual(self.user.pk, 42)
+        self.assertEqual(self.user.pk, "42")
 
     def test_is_staff(self):
-        payload = {api_settings.USER_ID_CLAIM: 42}
+        payload = {api_settings.USER_ID_CLAIM: "42"}
         user = TokenUser(payload)
 
         self.assertFalse(user.is_staff)
@@ -57,7 +57,7 @@ class TestTokenUser(TestCase):
         self.assertTrue(user.is_staff)
 
     def test_is_superuser(self):
-        payload = {api_settings.USER_ID_CLAIM: 42}
+        payload = {api_settings.USER_ID_CLAIM: "42"}
         user = TokenUser(payload)
 
         self.assertFalse(user.is_superuser)
@@ -68,15 +68,15 @@ class TestTokenUser(TestCase):
         self.assertTrue(user.is_superuser)
 
     def test_eq(self):
-        user1 = TokenUser({api_settings.USER_ID_CLAIM: 1})
-        user2 = TokenUser({api_settings.USER_ID_CLAIM: 2})
-        user3 = TokenUser({api_settings.USER_ID_CLAIM: 1})
+        user1 = TokenUser({api_settings.USER_ID_CLAIM: "1"})
+        user2 = TokenUser({api_settings.USER_ID_CLAIM: "2"})
+        user3 = TokenUser({api_settings.USER_ID_CLAIM: "1"})
 
         self.assertNotEqual(user1, user2)
         self.assertEqual(user1, user3)
 
     def test_eq_not_implemented(self):
-        user1 = TokenUser({api_settings.USER_ID_CLAIM: 1})
+        user1 = TokenUser({api_settings.USER_ID_CLAIM: "1"})
         user2 = "user2"
 
         self.assertFalse(user1 == user2)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -383,8 +383,7 @@ class TestToken(TestCase):
         token = MyToken.for_user(self.user)
 
         user_id = getattr(self.user, api_settings.USER_ID_FIELD)
-        if not isinstance(user_id, int):
-            user_id = str(user_id)
+        user_id = str(user_id)
 
         self.assertEqual(token[api_settings.USER_ID_CLAIM], user_id)
 
@@ -403,6 +402,10 @@ class TestToken(TestCase):
         token = MyToken()
 
         self.assertEqual(token.get_token_backend(), token_backend)
+
+    def test_token_user_id_claim_should_always_be_string(self):
+        token = MyToken.for_user(self.user)
+        self.assertIsInstance(token[api_settings.USER_ID_CLAIM], str)
 
 
 class TestSlidingToken(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps=
     drf314: djangorestframework>=3.14,<3.15
     drf315: djangorestframework>=3.15,<3.16
     pyjwt171: pyjwt>=1.7.1,<1.8
-    pyjwt2: pyjwt>=2,<2.10.0
+    pyjwt2: pyjwt>=2,<3
 allowlist_externals=make
 
 [testenv:docs]


### PR DESCRIPTION
`USER_ID_CLAIM` is often used as a `sub` claim, and according to the [RFC](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2), `sub` claim should always be string.

Django knows how to convert strings to int when doing database lookups so this should not make any problems there. So far any other value, but integers were stringified, this PR introduces a **breaking change**  where int values will also be stringified.

This is a first part of https://github.com/jazzband/djangorestframework-simplejwt/issues/831