### PR TITLE
fix: Do not copy `iat` claim from refresh token

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -386,6 +386,7 @@ class RefreshToken(BlacklistMixin["RefreshToken"], Token):
         # we wouldn't want to copy either one.
         api_settings.JTI_CLAIM,
         "jti",
+        "iat",
     )
     access_token_class = AccessToken
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from freezegun import freeze_time
 from jose import jwt
 
 from rest_framework_simplejwt.exceptions import (
@@ -434,10 +435,13 @@ class TestRefreshToken(TestCase):
 
     def test_access_token(self):
         # Should create an access token from a refresh token
-        refresh = RefreshToken()
-        refresh["test_claim"] = "arst"
+        with freeze_time("2025-01-01"):
+            refresh = RefreshToken()
+            refresh["test_claim"] = "arst"
 
-        access = refresh.access_token
+        with freeze_time("2025-01-02"):
+            # Ensure iat is different
+            access = refresh.access_token
 
         self.assertIsInstance(access, AccessToken)
         self.assertEqual(access[api_settings.TOKEN_TYPE_CLAIM], "access")


### PR DESCRIPTION
As @lwalejko pointed out, `iat` claim, according to the RFC, should not be copied from refresh token

>  The "iat" (issued at) claim identifies the time at which the JWT was issued.

Closes https://github.com/jazzband/djangorestframework-simplejwt/issues/778