### PR TITLE
fix: Incorrect `Token`, `TokenBackend` typing

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractBaseUser
@@ -11,6 +11,9 @@ from .models import TokenUser
 from .settings import api_settings
 from .tokens import Token
 from .utils import get_md5_hash_password
+
+if TYPE_CHECKING:
+    from .backends import RawToken
 
 AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
 
@@ -92,7 +95,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         return parts[1]
 
-    def get_validated_token(self, raw_token: bytes) -> Token:
+    def get_validated_token(self, raw_token: "RawToken") -> Token:
         """
         Validates an encoded JSON web token and returns a validated token
         wrapper object.

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -148,7 +148,7 @@ class TokenBackend:
         # For PyJWT >= 2.0.0a1
         return token
 
-    def decode(self, token: Token, verify: bool = True) -> dict[str, Any]:
+    def decode(self, token: Union[bytes, str], verify: bool = True) -> dict[str, Any]:
         """
         Performs a validation of the given token and returns its payload
         dictionary.

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Type
 
 from django.conf import settings
 from django.test.signals import setting_changed
@@ -7,6 +7,13 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.settings import APISettings as _APISettings
 
 from .utils import format_lazy
+
+if TYPE_CHECKING:
+    import json
+
+    from .authentication import AuthUser
+    from .models import TokenUser
+    from .tokens import Token
 
 USER_SETTINGS = getattr(settings, "SIMPLE_JWT", None)
 
@@ -63,6 +70,11 @@ REMOVED_SETTINGS = (
 
 
 class APISettings(_APISettings):  # pragma: no cover
+    AUTH_TOKEN_CLASSES: "Tuple[Type[Token], ...]"
+    JSON_ENCODER: "Optional[Type[json.JSONEncoder]]"
+    TOKEN_USER_CLASS: "Type[TokenUser]"
+    USER_AUTHENTICATION_RULE: "Callable[[AuthUser], bool]"
+
     def __check_user_settings(self, user_settings: dict[str, Any]) -> dict[str, Any]:
         SETTINGS_DOC = "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 from uuid import uuid4
 
 from django.conf import settings
@@ -27,7 +27,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from .backends import TokenBackend
+    from .backends import RawToken, TokenBackend
 
 T = TypeVar("T", bound="Token")
 
@@ -45,7 +45,7 @@ class Token:
 
     def __init__(
         self,
-        token: Union[None, bytes, str] = None,
+        token: Optional["RawToken"] = None,
         verify: bool = True,
     ) -> None:
         """

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union
 from uuid import uuid4
 
 from django.conf import settings
@@ -43,7 +43,11 @@ class Token:
     token_type: Optional[str] = None
     lifetime: Optional[timedelta] = None
 
-    def __init__(self, token: Optional["Token"] = None, verify: bool = True) -> None:
+    def __init__(
+        self,
+        token: Union[None, bytes, str] = None,
+        verify: bool = True,
+    ) -> None:
         """
         !!!! IMPORTANT !!!! MUST raise a TokenError with a user-facing error
         message if the given token is invalid, expired, or otherwise not safe


### PR DESCRIPTION
This PR aims to fix typing for the user-facing parts of `tokens.Token`, `backends.TokenBackend` classes:

1. Added The `RawToken` type to replace the erroneous `"Token"` annotation.
2. Expanded the incoming raw token type assumption to `bytes | str`, given the JWT backends support both.