### PR TITLE
fix: Various typing improvements

### DIFF
--- a/rest_framework_simplejwt/__init__.py
+++ b/rest_framework_simplejwt/__init__.py
@@ -1,4 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
+from typing import Union
+
+__version__: Union[str, None]
 
 try:
     __version__ = version("djangorestframework_simplejwt")

--- a/rest_framework_simplejwt/models.py
+++ b/rest_framework_simplejwt/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, TypeAlias, Union
 
 from django.contrib.auth import models as auth_models
 from django.db.models.manager import EmptyManager
@@ -7,10 +7,17 @@ from django.utils.functional import cached_property
 from .settings import api_settings
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser
+
     from .tokens import Token
 
+    TokenUserBase: TypeAlias = AbstractBaseUser
 
-class TokenUser:
+else:
+    TokenUserBase = object
+
+
+class TokenUser(TokenUserBase):
     """
     A dummy user class modeled after django.contrib.auth.models.AnonymousUser.
     Used in conjunction with the `JWTStatelessUserAuthentication` backend to

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -42,10 +42,10 @@ def datetime_from_epoch(ts: float) -> datetime:
     return dt
 
 
-def format_lazy(s: str, *args, **kwargs) -> str:
+def _format_lazy(s: str, *args, **kwargs) -> str:
     return s.format(*args, **kwargs)
 
 
-format_lazy: Callable = lazy(format_lazy, str)
+format_lazy: Callable = lazy(_format_lazy, str)
 
 logger = logging.getLogger("rest_framework_simplejwt")


### PR DESCRIPTION
- Resorted to using virtual subclassing instead of a current `TypeVar` for the `AuthToken`/`AbstractBaseUser` covariant type as it doesn't seem to play nice with Mypy.
- Added virtual subclassing to the mixin. Current `Generic` usage seems plain wrong.
- Added `if TYPE_CHECKING: assert self.user` assertions to `TokenObtainSerializer` implementations to make Mypy understand the serializer lifecycle.
- Added type-checking assertion for `lifetime` in `Token.set_exp`.
- Other minor improvements.