### PR TITLE
feat: improve TokenBlacklistSerializer return values

### DIFF
--- a/rest_framework_simplejwt/exceptions.py
+++ b/rest_framework_simplejwt/exceptions.py
@@ -54,3 +54,9 @@ class InvalidToken(AuthenticationFailed):
     status_code = status.HTTP_401_UNAUTHORIZED
     default_detail = _("Token is invalid or expired")
     default_code = "token_not_valid"
+
+
+class TokenBlacklistNotConfigured(DetailDictMixin, exceptions.APIException):
+    status_code = status.HTTP_501_NOT_IMPLEMENTED
+    default_detail = _("Token blacklist functionality is not enabled or available. Please check your configuration.")
+    default_code = "blacklist_not_configured"

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import AuthenticationFailed, ValidationError
 from .models import TokenUser
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
+from .exceptions import TokenBlacklistNotConfigured
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
@@ -189,5 +190,6 @@ class TokenBlacklistSerializer(serializers.Serializer):
         try:
             refresh.blacklist()
         except AttributeError:
-            pass
-        return {}
+            raise TokenBlacklistNotConfigured()
+        
+        return {"message": "Token blacklisted"}

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -8,7 +8,7 @@ from django.core import exceptions as django_exceptions
 from django.test import TestCase, override_settings
 from rest_framework import exceptions as drf_exceptions
 
-from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.exceptions import TokenError, TokenBlacklistNotConfigured
 from rest_framework_simplejwt.serializers import (
     TokenBlacklistSerializer,
     TokenObtainPairSerializer,
@@ -561,7 +561,7 @@ class TestTokenBlacklistSerializer(TestCase):
 
         self.assertIn("wrong type", e.exception.args[0])
 
-    def test_it_should_return_nothing_if_everything_ok(self):
+    def test_it_should_return_message_if_everything_ok(self):
         refresh = RefreshToken()
         refresh["test_claim"] = "arst"
 
@@ -574,7 +574,7 @@ class TestTokenBlacklistSerializer(TestCase):
             fake_aware_utcnow.return_value = now
             self.assertTrue(s.is_valid())
 
-        self.assertDictEqual(s.validated_data, {})
+        self.assertDictEqual(s.validated_data, {"message": "Token blacklisted"})
 
     def test_it_should_blacklist_refresh_token_if_everything_ok(self):
         self.assertEqual(OutstandingToken.objects.count(), 0)
@@ -601,24 +601,27 @@ class TestTokenBlacklistSerializer(TestCase):
         # Assert old refresh token is blacklisted
         self.assertEqual(BlacklistedToken.objects.first().token.jti, old_jti)
 
-    def test_blacklist_app_not_installed_should_pass(self):
+    def test_blacklist_app_not_installed_should_raise_token_blacklist_not_configured(self):
         from rest_framework_simplejwt import serializers, tokens
 
         # Remove blacklist app
         new_apps = list(settings.INSTALLED_APPS)
         new_apps.remove("rest_framework_simplejwt.token_blacklist")
 
-        with self.settings(INSTALLED_APPS=tuple(new_apps)):
-            # Reload module that blacklist app not installed
+        try:
+            with self.settings(INSTALLED_APPS=tuple(new_apps)):
+                # Reload module that blacklist app not installed
+                reload(tokens)
+                reload(serializers)
+
+                refresh = tokens.RefreshToken()
+
+                # Serializer validates
+                ser = serializers.TokenBlacklistSerializer(data={"refresh": str(refresh)})
+                
+                with self.assertRaises(TokenBlacklistNotConfigured):
+                    ser.validate({"refresh": str(refresh)})
+        finally:
+            # Restore origin module without mock
             reload(tokens)
             reload(serializers)
-
-            refresh = tokens.RefreshToken()
-
-            # Serializer validates
-            ser = serializers.TokenBlacklistSerializer(data={"refresh": str(refresh)})
-            ser.validate({"refresh": str(refresh)})
-
-        # Restore origin module without mock
-        reload(tokens)
-        reload(serializers)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -406,7 +406,7 @@ class TestTokenBlacklistView(APIViewTestCase):
 
         self.assertEqual(res.status_code, 200)
 
-        self.assertDictEqual(res.data, {})
+        self.assertDictEqual(res.data, {"message": "Token blacklisted"})
 
     def test_it_should_return_401_if_token_is_blacklisted(self):
         refresh = RefreshToken()


### PR DESCRIPTION
- Raise **TokenBlacklistNotConfigured**  exception when **token_blacklist** app is not installed, returning an error message and a **501 Not Implemented** status code.
- Return a success message ('Token blacklisted') when a token is successfully blacklisted.
- Update tests to reflect the new return behavior.

Tackles Issue #742 

### Tests name changes

#### In test_serializers.py
 * test_it_should_return_nothing_if_everything_ok   -->  test_it_should_return_message_if_everything_ok

#### In test_views.py
* test_blacklist_app_not_installed_should_pass  -->  test_blacklist_app_not_installed_should_raise_token_blacklist_not_configured