### PR TITLE
Add Django 5.2 support to test matrix and packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ['4.2', '5.0', '5.1']
+        django-version: ['4.2', '5.0', '5.1', '5.2']
         drf-version: ['3.14', '3.15']
         exclude:
           - drf-version: '3.14'

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=
     py{39,310,311,312}-dj42-drf{314,315}-pyjwt{171,2}-tests
     py{310,311,312}-dj50-drf315-pyjwt{171,2}-tests
     py{310,311,312,313}-dj51-drf315-pyjwt{171,2}-tests
+    py{311,312,313}-dj52-drf315-pyjwt{171,2}-tests
     docs
 
 [gh-actions]
@@ -18,6 +19,7 @@ DJANGO=
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
 DRF=
     3.14: drf314
     3.15: drf315
@@ -33,6 +35,7 @@ deps=
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     drf314: djangorestframework>=3.14,<3.15
     drf315: djangorestframework>=3.15,<3.16
     pyjwt171: pyjwt>=1.7.1,<1.8


### PR DESCRIPTION
# Add Django 5.2 support to test matrix and packaging

This pull request adds compatibility for **Django 5.2** in the test and packaging configuration.

## ✅ Changes included:
- Added **Django 5.2** to the `python-version` / `django-version` matrix in `.github/workflows/test.yml`
- Updated `tox.ini`:
  - Added Django 5.2 (`dj52`) to the environment list
  - Defined `Django>=5.2,<5.3` under the `[testenv]` dependencies
- Updated `setup.py`:
  - Added `Framework :: Django :: 5.2` to `classifiers`
---

These updates ensure that **`djangorestframework-simplejwt`** is fully tested against and marked as compatible with the latest stable Django release (5.2).
