### PR TITLE
Make AUTH_HEADER_TYPES case-insensitive as per RFC7235

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -184,6 +184,10 @@ requiring authentication would look for a header with the following format:
 tuple of possible header types (e.g. ``('Bearer', 'JWT')``).  If a list or
 tuple is used in this way, and authentication fails, the first item in the
 collection will be used to build the "WWW-Authenticate" header in the response.
+As per As per RFC7235 auth scheme is case insensitive. For example, setting the header
+types to ``('Bearer', 'JWT')`` will correctly auth ``Authorization: Bearer <token>`` as
+well as ``Authorization: bearer <token>`` and ``Authorization: jwt <token>`` headers.
+
 
 ``AUTH_HEADER_NAME``
 ----------------------------

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -17,8 +17,9 @@ AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
 if not isinstance(api_settings.AUTH_HEADER_TYPES, (list, tuple)):
     AUTH_HEADER_TYPES = (AUTH_HEADER_TYPES,)
 
+
 AUTH_HEADER_TYPE_BYTES: set[bytes] = {
-    h.encode(HTTP_HEADER_ENCODING) for h in AUTH_HEADER_TYPES
+    h.lower().encode(HTTP_HEADER_ENCODING) for h in AUTH_HEADER_TYPES
 }
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
@@ -80,7 +81,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
             # Empty AUTHORIZATION header sent
             return None
 
-        if parts[0] not in AUTH_HEADER_TYPE_BYTES:
+        if parts[0].lower() not in AUTH_HEADER_TYPE_BYTES:
             # Assume the header does not contain a JSON web token
             return None
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -76,6 +76,14 @@ class TestJWTAuthentication(TestCase):
         reload(authentication)
         self.assertIsNone(self.backend.get_raw_token(self.fake_header))
 
+    @override_api_settings(AUTH_HEADER_TYPES="BeAreR")
+    def test_get_raw_token_header_keyword_case_insensitive(self):
+        # Should return token if header keyword matches case-insensitive.
+        # AUTH_HEADER_TYPES is "BeAreR", but header is "Bearer"
+        reload(authentication)
+        self.assertEqual(self.backend.get_raw_token(self.fake_header),
+            self.fake_token, )
+
     @override_api_settings(AUTH_HEADER_TYPES=("JWT", "Bearer"))
     def test_get_raw_token_multi_header_keyword(self):
         # Should return token if header has one of many valid token types
@@ -84,6 +92,14 @@ class TestJWTAuthentication(TestCase):
             self.backend.get_raw_token(self.fake_header),
             self.fake_token,
         )
+
+    @override_api_settings(AUTH_HEADER_TYPES=("jwt", "bearer"))
+    def test_get_raw_token_multi_header_keyword_case_insensitive(self):
+        # Should return token if header has one of many valid token types, even if the
+        # case differs.
+        reload(authentication)
+        self.assertEqual(self.backend.get_raw_token(self.fake_header),
+            self.fake_token, )
 
     def test_get_validated_token(self):
         # Should raise InvalidToken if token not valid

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -81,8 +81,10 @@ class TestJWTAuthentication(TestCase):
         # Should return token if header keyword matches case-insensitive.
         # AUTH_HEADER_TYPES is "BeAreR", but header is "Bearer"
         reload(authentication)
-        self.assertEqual(self.backend.get_raw_token(self.fake_header),
-            self.fake_token, )
+        self.assertEqual(
+            self.backend.get_raw_token(self.fake_header),
+            self.fake_token,
+        )
 
     @override_api_settings(AUTH_HEADER_TYPES=("JWT", "Bearer"))
     def test_get_raw_token_multi_header_keyword(self):
@@ -98,8 +100,10 @@ class TestJWTAuthentication(TestCase):
         # Should return token if header has one of many valid token types, even if the
         # case differs.
         reload(authentication)
-        self.assertEqual(self.backend.get_raw_token(self.fake_header),
-            self.fake_token, )
+        self.assertEqual(
+            self.backend.get_raw_token(self.fake_header),
+            self.fake_token,
+        )
 
     def test_get_validated_token(self):
         # Should raise InvalidToken if token not valid


### PR DESCRIPTION
This pull request changes the way the AUTH_HEADER_TYPES are parsed in order to make them case-insensitive.