### PR TITLE
fix: stop using deprecated set-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache
       uses: actions/cache@v4


### PR DESCRIPTION
`set-output` has been deprecated since 2022 (https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/).

This PR replaces it with newer sytax
