### PR TITLE
Add configurable issuer/audience validation with dynamic claim support

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -24,7 +24,11 @@ Some of Simple JWT's behavior can be customized through settings variables in
       "SIGNING_KEY": settings.SECRET_KEY,
       "VERIFYING_KEY": "",
       "AUDIENCE": None,
+      "AUDIENCE_VALIDATION": "static",
       "ISSUER": None,
+      "ISSUER_VALIDATION": "static",
+      "ISS_CLAIM": "iss",
+      "ALLOWED_ISSUERS": None,
       "JSON_ENCODER": None,
       "JWK_URL": None,
       "LEEWAY": 0,
@@ -192,6 +196,18 @@ Dynamic audience example::
 The issuer claim to be included in generated tokens and/or validated in decoded
 tokens. When set to ``None``, this field is excluded from tokens and is not
 validated.
+
+``ISS_CLAIM``
+-------------
+
+The claim name used for the issuer in token payloads. Defaults to ``"iss"``.
+
+``ALLOWED_ISSUERS``
+-------------------
+
+Optional list/tuple of acceptable issuer values when using dynamic issuer
+validation. When set to ``None``, any non-empty issuer string is accepted in
+dynamic mode.
 
 ``ISSUER_VALIDATION``
 ---------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -162,6 +162,17 @@ The issuer claim to be included in generated tokens and/or validated in decoded
 tokens. When set to ``None``, this field is excluded from tokens and is not
 validated.
 
+``ISSUER_VALIDATION``
+---------------------
+
+Controls how the issuer claim is validated during backend decode. Valid values:
+
+* ``"static"`` (default): The backend passes ``ISSUER`` to PyJWT, which performs
+  issuer validation at decode time.
+* ``"dynamic"``: The backend does not pass an issuer to PyJWT, allowing tokens
+  with dynamically assigned issuers to be decoded. Issuer validation is then
+  handled in ``Token.verify_iss``.
+
 ``JWK_URL``
 -----------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -167,6 +167,25 @@ Controls how the audience claim is validated during backend decode. Valid values
   with dynamically assigned audiences to be decoded. Audience validation is then
   handled in ``Token.verify_aud`` (ensuring the claim exists and is non-empty).
 
+Dynamic audience example::
+
+    from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+    class AudienceAwareTokenSerializer(TokenObtainPairSerializer):
+        @classmethod
+        def get_token(cls, user):
+            token = super().get_token(user)
+
+            audience = getattr(user, "aud_for_token", None)
+            if audience:
+                token.set_aud(audience=audience)
+
+            return token
+
+.. note::
+   To allow dynamic audiences, set ``AUDIENCE_VALIDATION="dynamic"`` so the
+   backend does not enforce a single static audience via PyJWT.
+
 ``ISSUER``
 ----------
 
@@ -184,6 +203,25 @@ Controls how the issuer claim is validated during backend decode. Valid values:
 * ``"dynamic"``: The backend does not pass an issuer to PyJWT, allowing tokens
   with dynamically assigned issuers to be decoded. Issuer validation is then
   handled in ``Token.verify_iss``.
+
+Dynamic issuer example::
+
+    from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+    class TenantAwareTokenSerializer(TokenObtainPairSerializer):
+        @classmethod
+        def get_token(cls, user):
+            token = super().get_token(user)
+
+            issuer = getattr(user, "issuer_for_token", None)
+            if issuer:
+                token.set_iss(issuer=issuer)
+
+            return token
+
+.. note::
+   To allow dynamic issuers, set ``ISSUER_VALIDATION="dynamic"`` so the backend
+   does not enforce a single static issuer via PyJWT.
 
 ``JWK_URL``
 -----------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -155,6 +155,18 @@ The audience claim to be included in generated tokens and/or validated in
 decoded tokens. When set to ``None``, this field is excluded from tokens and is
 not validated.
 
+``AUDIENCE_VALIDATION``
+-----------------------
+
+Controls how the audience claim is validated during backend decode. Valid values:
+
+* ``"static"`` (default): The backend passes ``AUDIENCE`` to PyJWT, which performs
+  audience validation at decode time. Tokens carrying an ``aud`` that does not
+  match the configured audience are rejected by PyJWT.
+* ``"dynamic"``: The backend does not pass an audience to PyJWT, allowing tokens
+  with dynamically assigned audiences to be decoded. Audience validation is then
+  handled in ``Token.verify_aud`` (ensuring the claim exists and is non-empty).
+
 ``ISSUER``
 ----------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -26,9 +26,7 @@ Some of Simple JWT's behavior can be customized through settings variables in
       "AUDIENCE": None,
       "AUDIENCE_VALIDATION": "static",
       "ISSUER": None,
-      "ISSUER_VALIDATION": "static",
       "ISSUER_CLAIM": "iss",
-      "ALLOWED_ISSUERS": None,
       "JSON_ENCODER": None,
       "JWK_URL": None,
       "LEEWAY": 0,
@@ -193,34 +191,17 @@ Dynamic audience example::
 ``ISSUER``
 ----------
 
-The issuer claim to be included in generated tokens and/or validated in decoded
-tokens. When set to ``None``, this field is excluded from tokens and is not
-validated.
+Controls issuer generation and validation:
 
-``ISSUER_CLAIM``
--------------
+* ``None`` (default): The issuer claim is not generated and is not validated.
+* A non-empty string: The value is emitted as the token's ``iss`` claim and is
+  also enforced during decode as a single expected issuer.
+* A list/tuple of non-empty strings: The value acts as a verification-only
+  whitelist. Simple JWT does not emit ``iss`` automatically in this mode, and
+  ``Token.verify_iss()`` accepts any configured issuer after decode.
 
-The claim name used for the issuer in token payloads. Defaults to ``"iss"``.
-
-``ALLOWED_ISSUERS``
--------------------
-
-Optional list/tuple of acceptable issuer values when using dynamic issuer
-validation. When set to ``None``, any non-empty issuer string is accepted in
-dynamic mode.
-
-``ISSUER_VALIDATION``
----------------------
-
-Controls how the issuer claim is validated during backend decode. Valid values:
-
-* ``"static"`` (default): The backend passes ``ISSUER`` to PyJWT, which performs
-  issuer validation at decode time.
-* ``"dynamic"``: The backend does not pass an issuer to PyJWT, allowing tokens
-  with dynamically assigned issuers to be decoded. Issuer validation is then
-  handled in ``Token.verify_iss``.
-
-Dynamic issuer example::
+If you need to generate a token with a dynamic issuer while using an issuer
+whitelist, set the claim explicitly in custom token code::
 
     from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
@@ -235,9 +216,10 @@ Dynamic issuer example::
 
             return token
 
-.. note::
-   To allow dynamic issuers, set ``ISSUER_VALIDATION="dynamic"`` so the backend
-   does not enforce a single static issuer via PyJWT.
+``ISSUER_CLAIM``
+-------------
+
+The claim name used for the issuer in token payloads. Defaults to ``"iss"``.
 
 ``JWK_URL``
 -----------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -27,7 +27,7 @@ Some of Simple JWT's behavior can be customized through settings variables in
       "AUDIENCE_VALIDATION": "static",
       "ISSUER": None,
       "ISSUER_VALIDATION": "static",
-      "ISS_CLAIM": "iss",
+      "ISSUER_CLAIM": "iss",
       "ALLOWED_ISSUERS": None,
       "JSON_ENCODER": None,
       "JWK_URL": None,
@@ -197,7 +197,7 @@ The issuer claim to be included in generated tokens and/or validated in decoded
 tokens. When set to ``None``, this field is excluded from tokens and is not
 validated.
 
-``ISS_CLAIM``
+``ISSUER_CLAIM``
 -------------
 
 The claim name used for the issuer in token payloads. Defaults to ``"iss"``.

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -48,8 +48,8 @@ class TokenBackend:
         jwk_url: str | None = None,
         leeway: float | int | timedelta | None = None,
         json_encoder: type[json.JSONEncoder] | None = None,
-        verify_aud: Optional[bool] = None,
-        verify_iss: Optional[bool] = None,
+        verify_aud: bool | None = None,
+        verify_iss: bool | None = None,
     ) -> None:
         self._validate_algorithm(algorithm)
 

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import Iterable
 from datetime import timedelta
 from functools import cached_property
-from typing import Any
+from typing import Any, Optional
 
 import jwt
 from django.utils.translation import gettext_lazy as _

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -55,7 +55,7 @@ class TokenBackend:
         self.signing_key = signing_key
         self.verifying_key = verifying_key
         self.audience = audience
-        self.issuer = issuer
+        # self.issuer = issuer
 
         if JWK_CLIENT_AVAILABLE:
             self.jwks_client = PyJWKClient(jwk_url) if jwk_url else None
@@ -133,8 +133,8 @@ class TokenBackend:
         jwt_payload = payload.copy()
         if self.audience is not None:
             jwt_payload["aud"] = self.audience
-        if self.issuer is not None:
-            jwt_payload["iss"] = self.issuer
+        # if self.issuer is not None:
+        #     jwt_payload["iss"] = self.issuer
 
         token = jwt.encode(
             jwt_payload,
@@ -156,17 +156,19 @@ class TokenBackend:
         Raises a `TokenBackendError` if the token is malformed, if its
         signature check fails, or if its 'exp' claim indicates it has expired.
         """
+        # WIP
         try:
             return jwt.decode(
                 token,
                 self.get_verifying_key(token),
                 algorithms=[self.algorithm],
                 audience=self.audience,
-                issuer=self.issuer,
+                # issuer=self.issuer,
                 leeway=self.get_leeway(),
                 options={
                     "verify_aud": self.audience is not None,
                     "verify_signature": verify,
+                    # "verify_iss": self.issuer is not None,
                 },
             )
         except InvalidAlgorithmError as e:

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -166,7 +166,6 @@ class TokenBackend:
         Raises a `TokenBackendError` if the token is malformed, if its
         signature check fails, or if its 'exp' claim indicates it has expired.
         """
-        # WIP
         try:
             return jwt.decode(
                 token,

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -48,6 +48,8 @@ class TokenBackend:
         jwk_url: str | None = None,
         leeway: float | int | timedelta | None = None,
         json_encoder: type[json.JSONEncoder] | None = None,
+        verify_aud: Optional[bool] = None,
+        verify_iss: Optional[bool] = None,
     ) -> None:
         self._validate_algorithm(algorithm)
 
@@ -56,6 +58,14 @@ class TokenBackend:
         self.verifying_key = verifying_key
         self.audience = audience
         self.issuer = issuer
+
+        self.verify_aud = audience is not None
+        if verify_aud is not None:
+            self.verify_aud = verify_aud
+
+        self.verify_iss = issuer is not None
+        if verify_iss is not None:
+            self.verify_iss = verify_iss
 
         if JWK_CLIENT_AVAILABLE:
             self.jwks_client = PyJWKClient(jwk_url) if jwk_url else None
@@ -166,9 +176,9 @@ class TokenBackend:
                 issuer=self.issuer,
                 leeway=self.get_leeway(),
                 options={
-                    "verify_aud": self.audience is not None,
+                    "verify_aud": self.verify_aud,
                     "verify_signature": verify,
-                    "verify_iss": self.issuer is not None,
+                    "verify_iss": self.verify_iss,
                 },
             )
         except InvalidAlgorithmError as e:

--- a/rest_framework_simplejwt/backends.py
+++ b/rest_framework_simplejwt/backends.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import Iterable
 from datetime import timedelta
 from functools import cached_property
-from typing import Any, Optional, Union
+from typing import Any
 
 import jwt
 from django.utils.translation import gettext_lazy as _
@@ -55,7 +55,7 @@ class TokenBackend:
         self.signing_key = signing_key
         self.verifying_key = verifying_key
         self.audience = audience
-        # self.issuer = issuer
+        self.issuer = issuer
 
         if JWK_CLIENT_AVAILABLE:
             self.jwks_client = PyJWKClient(jwk_url) if jwk_url else None
@@ -133,8 +133,8 @@ class TokenBackend:
         jwt_payload = payload.copy()
         if self.audience is not None:
             jwt_payload["aud"] = self.audience
-        # if self.issuer is not None:
-        #     jwt_payload["iss"] = self.issuer
+        if self.issuer is not None:
+            jwt_payload["iss"] = self.issuer
 
         token = jwt.encode(
             jwt_payload,
@@ -163,12 +163,12 @@ class TokenBackend:
                 self.get_verifying_key(token),
                 algorithms=[self.algorithm],
                 audience=self.audience,
-                # issuer=self.issuer,
+                issuer=self.issuer,
                 leeway=self.get_leeway(),
                 options={
                     "verify_aud": self.audience is not None,
                     "verify_signature": verify,
-                    # "verify_iss": self.issuer is not None,
+                    "verify_iss": self.issuer is not None,
                 },
             )
         except InvalidAlgorithmError as e:

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -168,6 +168,7 @@ class TokenRefreshSerializer(serializers.Serializer):
             refresh.set_jti()
             refresh.set_exp()
             refresh.set_iat()
+            refresh.set_iss()
             refresh.outstand()
 
             data["refresh"] = str(refresh)

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -21,6 +21,8 @@ DEFAULTS = {
     "VERIFYING_KEY": "",
     "AUDIENCE": None,
     "ISSUER": None,
+    "ISS_CLAIM": "iss",
+    "ALLOWED_ISSUERS": None,
     "JSON_ENCODER": None,
     "JWK_URL": None,
     "LEEWAY": 0,

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -20,6 +20,7 @@ DEFAULTS = {
     "SIGNING_KEY": settings.SECRET_KEY,
     "VERIFYING_KEY": "",
     "AUDIENCE": None,
+    "AUDIENCE_VALIDATION": "static",
     "ISSUER": None,
     "ISSUER_VALIDATION": "static",
     "ISS_CLAIM": "iss",

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -21,6 +21,7 @@ DEFAULTS = {
     "VERIFYING_KEY": "",
     "AUDIENCE": None,
     "ISSUER": None,
+    "ISSUER_VALIDATION": "static",
     "ISS_CLAIM": "iss",
     "ALLOWED_ISSUERS": None,
     "JSON_ENCODER": None,

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -23,7 +23,7 @@ DEFAULTS = {
     "AUDIENCE_VALIDATION": "static",
     "ISSUER": None,
     "ISSUER_VALIDATION": "static",
-    "ISS_CLAIM": "iss",
+    "ISSUER_CLAIM": "iss",
     "ALLOWED_ISSUERS": None,
     "JSON_ENCODER": None,
     "JWK_URL": None,

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -125,8 +125,10 @@ class APISettings(_APISettings):  # pragma: no cover
                 settings_doc,
             )
 
-        if not isinstance(issuer, (list, tuple)) or not issuer or any(
-            not isinstance(item, str) or not item.strip() for item in issuer
+        if (
+            not isinstance(issuer, (list, tuple))
+            or not issuer
+            or any(not isinstance(item, str) or not item.strip() for item in issuer)
         ):
             self._raise_invalid_setting(
                 "The 'ISSUER' setting must be a non-empty string or a list/tuple of non-empty strings. Please refer to '{}' for available settings.",

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -22,9 +22,7 @@ DEFAULTS = {
     "AUDIENCE": None,
     "AUDIENCE_VALIDATION": "static",
     "ISSUER": None,
-    "ISSUER_VALIDATION": "static",
     "ISSUER_CLAIM": "iss",
-    "ALLOWED_ISSUERS": None,
     "JSON_ENCODER": None,
     "JWK_URL": None,
     "LEEWAY": 0,
@@ -69,7 +67,7 @@ REMOVED_SETTINGS = (
     "TOKEN_BACKEND_CLASS",
 )
 
-VALIDATION_MODES = ("static", "dynamic")
+AUDIENCE_VALIDATION_MODES = ("static", "dynamic")
 
 
 class APISettings(_APISettings):  # pragma: no cover
@@ -98,58 +96,40 @@ class APISettings(_APISettings):  # pragma: no cover
     def _validate_validation_modes(
         self, user_settings: dict[str, Any], settings_doc: str
     ) -> None:
-        for setting in ("AUDIENCE_VALIDATION", "ISSUER_VALIDATION"):
-            value = user_settings.get(setting)
-            if value is not None and value not in VALIDATION_MODES:
-                self._raise_invalid_setting(
-                    "The '{}' setting must be one of {}. Please refer to '{}' for available settings.",
-                    settings_doc,
-                    setting,
-                    VALIDATION_MODES,
-                )
-
-    def _validate_allowed_issuers(
-        self, allowed_issuers: Any, settings_doc: str
-    ) -> None:
-        if allowed_issuers is None:
-            return
-
-        if not isinstance(allowed_issuers, (list, tuple)):
-            self._raise_invalid_setting(
-                "The 'ALLOWED_ISSUERS' setting must be a list or tuple. Please refer to '{}' for available settings.",
-                settings_doc,
-            )
-
-        if not allowed_issuers or any(
-            not isinstance(issuer, str) or not issuer.strip()
-            for issuer in allowed_issuers
+        audience_validation = user_settings.get("AUDIENCE_VALIDATION")
+        if (
+            audience_validation is not None
+            and audience_validation not in AUDIENCE_VALIDATION_MODES
         ):
             self._raise_invalid_setting(
-                "The 'ALLOWED_ISSUERS' setting must contain non-empty strings. Please refer to '{}' for available settings.",
+                "The '{}' setting must be one of {}. Please refer to '{}' for available settings.",
                 settings_doc,
+                "AUDIENCE_VALIDATION",
+                AUDIENCE_VALIDATION_MODES,
             )
 
     def _validate_issuer_settings(
         self, user_settings: dict[str, Any], settings_doc: str
     ) -> None:
-        issuer_validation = user_settings.get("ISSUER_VALIDATION")
-        allowed_issuers = user_settings.get("ALLOWED_ISSUERS")
+        issuer = user_settings.get("ISSUER")
 
-        self._validate_allowed_issuers(allowed_issuers, settings_doc)
+        if issuer is None:
+            return
 
-        if issuer_validation == "static" and allowed_issuers is not None:
+        if isinstance(issuer, str):
+            if issuer.strip():
+                return
+
             self._raise_invalid_setting(
-                "The 'ALLOWED_ISSUERS' setting requires 'ISSUER_VALIDATION' to be 'dynamic'. Please refer to '{}' for available settings.",
+                "The 'ISSUER' setting must be a non-empty string or a list/tuple of non-empty strings. Please refer to '{}' for available settings.",
                 settings_doc,
             )
 
-        if (
-            issuer_validation == "dynamic"
-            and user_settings.get("ISSUER") is not None
-            and allowed_issuers is not None
+        if not isinstance(issuer, (list, tuple)) or not issuer or any(
+            not isinstance(item, str) or not item.strip() for item in issuer
         ):
             self._raise_invalid_setting(
-                "The 'ISSUER' and 'ALLOWED_ISSUERS' settings cannot both be set when 'ISSUER_VALIDATION' is 'dynamic'. Please refer to '{}' for available settings.",
+                "The 'ISSUER' setting must be a non-empty string or a list/tuple of non-empty strings. Please refer to '{}' for available settings.",
                 settings_doc,
             )
 

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -69,22 +69,96 @@ REMOVED_SETTINGS = (
     "TOKEN_BACKEND_CLASS",
 )
 
+VALIDATION_MODES = ("static", "dynamic")
+
 
 class APISettings(_APISettings):  # pragma: no cover
-    def __check_user_settings(self, user_settings: dict[str, Any]) -> dict[str, Any]:
-        SETTINGS_DOC = "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
+    def _raise_invalid_setting(self, message: str, settings_doc: str, *args: Any) -> None:
+        raise RuntimeError(
+            format_lazy(
+                _(message),
+                *args,
+                settings_doc,
+            )
+        )
 
+    def _validate_removed_settings(
+        self, user_settings: dict[str, Any], settings_doc: str
+    ) -> None:
         for setting in REMOVED_SETTINGS:
             if setting in user_settings:
-                raise RuntimeError(
-                    format_lazy(
-                        _(
-                            "The '{}' setting has been removed. Please refer to '{}' for available settings."
-                        ),
-                        setting,
-                        SETTINGS_DOC,
-                    )
+                self._raise_invalid_setting(
+                    "The '{}' setting has been removed. Please refer to '{}' for available settings.",
+                    settings_doc,
+                    setting,
                 )
+
+    def _validate_validation_modes(
+        self, user_settings: dict[str, Any], settings_doc: str
+    ) -> None:
+        for setting in ("AUDIENCE_VALIDATION", "ISSUER_VALIDATION"):
+            value = user_settings.get(setting)
+            if value is not None and value not in VALIDATION_MODES:
+                self._raise_invalid_setting(
+                    "The '{}' setting must be one of {}. Please refer to '{}' for available settings.",
+                    settings_doc,
+                    setting,
+                    VALIDATION_MODES,
+                )
+
+    def _validate_allowed_issuers(
+        self, allowed_issuers: Any, settings_doc: str
+    ) -> None:
+        if allowed_issuers is None:
+            return
+
+        if not isinstance(allowed_issuers, (list, tuple)):
+            self._raise_invalid_setting(
+                "The 'ALLOWED_ISSUERS' setting must be a list or tuple. Please refer to '{}' for available settings.",
+                settings_doc,
+            )
+
+        if not allowed_issuers or any(
+            not isinstance(issuer, str) or not issuer.strip()
+            for issuer in allowed_issuers
+        ):
+            self._raise_invalid_setting(
+                "The 'ALLOWED_ISSUERS' setting must contain non-empty strings. Please refer to '{}' for available settings.",
+                settings_doc,
+            )
+
+    def _validate_issuer_settings(
+        self, user_settings: dict[str, Any], settings_doc: str
+    ) -> None:
+        issuer_validation = user_settings.get("ISSUER_VALIDATION")
+        allowed_issuers = user_settings.get("ALLOWED_ISSUERS")
+
+        self._validate_allowed_issuers(allowed_issuers, settings_doc)
+
+        if issuer_validation == "static" and allowed_issuers is not None:
+            self._raise_invalid_setting(
+                "The 'ALLOWED_ISSUERS' setting requires 'ISSUER_VALIDATION' to be 'dynamic'. Please refer to '{}' for available settings.",
+                settings_doc,
+            )
+
+        if (
+            issuer_validation == "dynamic"
+            and user_settings.get("ISSUER") is not None
+            and allowed_issuers is not None
+        ):
+            self._raise_invalid_setting(
+                "The 'ISSUER' and 'ALLOWED_ISSUERS' settings cannot both be set when 'ISSUER_VALIDATION' is 'dynamic'. Please refer to '{}' for available settings.",
+                settings_doc,
+            )
+
+    def __check_user_settings(self, user_settings: dict[str, Any]) -> dict[str, Any]:
+        settings_doc = (
+            "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
+        )
+
+        self._validate_removed_settings(user_settings, settings_doc)
+        self._validate_validation_modes(user_settings, settings_doc)
+        self._validate_issuer_settings(user_settings, settings_doc)
 
         return user_settings
 

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -73,7 +73,9 @@ VALIDATION_MODES = ("static", "dynamic")
 
 
 class APISettings(_APISettings):  # pragma: no cover
-    def _raise_invalid_setting(self, message: str, settings_doc: str, *args: Any) -> None:
+    def _raise_invalid_setting(
+        self, message: str, settings_doc: str, *args: Any
+    ) -> None:
         raise RuntimeError(
             format_lazy(
                 _(message),
@@ -152,9 +154,7 @@ class APISettings(_APISettings):  # pragma: no cover
             )
 
     def __check_user_settings(self, user_settings: dict[str, Any]) -> dict[str, Any]:
-        settings_doc = (
-            "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
-        )
+        settings_doc = "https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html"
 
         self._validate_removed_settings(user_settings, settings_doc)
         self._validate_validation_modes(user_settings, settings_doc)

--- a/rest_framework_simplejwt/state.py
+++ b/rest_framework_simplejwt/state.py
@@ -5,7 +5,7 @@ token_backend = TokenBackend(
     api_settings.ALGORITHM,
     api_settings.SIGNING_KEY,
     api_settings.VERIFYING_KEY,
-    api_settings.AUDIENCE,
+    api_settings.AUDIENCE if api_settings.AUDIENCE_VALIDATION == "static" else None,
     api_settings.ISSUER if api_settings.ISSUER_VALIDATION == "static" else None,
     api_settings.JWK_URL,
     api_settings.LEEWAY,

--- a/rest_framework_simplejwt/state.py
+++ b/rest_framework_simplejwt/state.py
@@ -6,7 +6,7 @@ token_backend = TokenBackend(
     api_settings.SIGNING_KEY,
     api_settings.VERIFYING_KEY,
     api_settings.AUDIENCE,
-    # api_settings.ISSUER,
+    api_settings.ISSUER if api_settings.ISSUER_VALIDATION == "static" else None,
     api_settings.JWK_URL,
     api_settings.LEEWAY,
     api_settings.JSON_ENCODER,

--- a/rest_framework_simplejwt/state.py
+++ b/rest_framework_simplejwt/state.py
@@ -6,7 +6,7 @@ token_backend = TokenBackend(
     api_settings.SIGNING_KEY,
     api_settings.VERIFYING_KEY,
     api_settings.AUDIENCE,
-    api_settings.ISSUER,
+    # api_settings.ISSUER,
     api_settings.JWK_URL,
     api_settings.LEEWAY,
     api_settings.JSON_ENCODER,

--- a/rest_framework_simplejwt/state.py
+++ b/rest_framework_simplejwt/state.py
@@ -6,7 +6,7 @@ token_backend = TokenBackend(
     api_settings.SIGNING_KEY,
     api_settings.VERIFYING_KEY,
     api_settings.AUDIENCE if api_settings.AUDIENCE_VALIDATION == "static" else None,
-    api_settings.ISSUER if api_settings.ISSUER_VALIDATION == "static" else None,
+    api_settings.ISSUER if isinstance(api_settings.ISSUER, str) else None,
     api_settings.JWK_URL,
     api_settings.LEEWAY,
     api_settings.JSON_ENCODER,

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -177,7 +177,7 @@ class Token:
         """
         Returns the issuer URL configured in the settings.
         """
-        return issuer or self.payload.get(api_settings.ISSUER)
+        return issuer or api_settings.ISSUER
 
     def set_iss(
         self, claim: str = api_settings.ISS_CLAIM, issuer: str | None = None

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -236,7 +236,7 @@ class Token:
         else:
             raise TokenError(_("Token has invalid audience"))
 
-    def get_iss(self, issuer: str | None = None) -> Optional[str]:
+    def get_iss(self, issuer: str | None = None) -> str | None:
         """
         Returns the issuer URL configured in the settings.
         """
@@ -258,7 +258,7 @@ class Token:
 
     def get_aud(
         self, audience: str | list[str] | None = None
-    ) -> Optional[str | list[str]]:
+    ) -> str | list[str] | None:
         """
         Returns the audience configured in the settings or the provided value.
         """

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -153,12 +153,10 @@ class Token:
         """
         Validates the issuer claim in the token payload.
 
-        For dynamic issuers: Just verifies that the iss claim exists and
-        is a non-empty string. Optionally validates against a whitelist
-        if ALLOWED_ISSUERS is configured.
-
-        For static issuers: If ISSUER is configured in settings, validates
-        that the token's iss claim matches the configured value.
+        If ISSUER is configured as a string, the token's issuer must match it.
+        If ISSUER is configured as a list/tuple, the token's issuer must be one
+        of the configured values. Otherwise, if the token carries an issuer
+        claim, it must be a non-empty string.
         """
         issuer = self.payload.get(api_settings.ISSUER_CLAIM)
 
@@ -168,14 +166,18 @@ class Token:
         if not isinstance(issuer, str) or not issuer.strip():
             raise TokenError(_("Token has invalid issuer"))
 
-        if api_settings.ISSUER is not None:
-            if issuer != api_settings.ISSUER:
+        expected = api_settings.ISSUER
+
+        if isinstance(expected, str):
+            if issuer != expected:
                 raise TokenError(_("Token has invalid issuer"))
 
-        # If allowed issuers list is configured, validate against it
-        elif api_settings.ALLOWED_ISSUERS is not None:
-            if issuer not in api_settings.ALLOWED_ISSUERS:
+        elif isinstance(expected, (list, tuple)):
+            if issuer not in expected:
                 raise TokenError(_("Token has invalid issuer"))
+
+        elif expected is not None:
+            raise TokenError(_("Token has invalid issuer"))
 
     def verify_aud(self) -> None:
         """
@@ -238,9 +240,13 @@ class Token:
 
     def get_iss(self, issuer: str | None = None) -> str | None:
         """
-        Returns the issuer URL configured in the settings.
+        Returns the issuer string configured in the settings.
         """
-        return issuer or api_settings.ISSUER
+        if issuer is not None:
+            return issuer
+
+        configured_issuer = api_settings.ISSUER
+        return configured_issuer if isinstance(configured_issuer, str) else None
 
     def set_iss(
         self, claim: str = api_settings.ISSUER_CLAIM, issuer: str | None = None

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -134,10 +134,7 @@ class Token:
         if api_settings.AUDIENCE is not None or "aud" in self.payload:
             self.verify_aud()
 
-        if (
-            api_settings.ISSUER is not None
-            or api_settings.ISSUER_CLAIM in self.payload
-        ):
+        if api_settings.ISSUER is not None or api_settings.ISSUER_CLAIM in self.payload:
             self.verify_iss()
 
     def verify_token_type(self) -> None:

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -134,7 +134,10 @@ class Token:
         if api_settings.AUDIENCE is not None or "aud" in self.payload:
             self.verify_aud()
 
-        if api_settings.ISSUER is not None or api_settings.ISS_CLAIM in self.payload:
+        if (
+            api_settings.ISSUER is not None
+            or api_settings.ISSUER_CLAIM in self.payload
+        ):
             self.verify_iss()
 
     def verify_token_type(self) -> None:
@@ -160,7 +163,7 @@ class Token:
         For static issuers: If ISSUER is configured in settings, validates
         that the token's iss claim matches the configured value.
         """
-        issuer = self.payload.get(api_settings.ISS_CLAIM)
+        issuer = self.payload.get(api_settings.ISSUER_CLAIM)
 
         if issuer is None:
             raise TokenError(_("Token has no issuer"))
@@ -243,7 +246,7 @@ class Token:
         return issuer or api_settings.ISSUER
 
     def set_iss(
-        self, claim: str = api_settings.ISS_CLAIM, issuer: str | None = None
+        self, claim: str = api_settings.ISSUER_CLAIM, issuer: str | None = None
     ) -> None:
         """
         Populates the iss claim of a token with the issuer returned by the

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,60 +11,28 @@ def test_validation_mode_must_be_supported():
             IMPORT_STRINGS,
         )
 
-    with pytest.raises(RuntimeError, match="ISSUER_VALIDATION"):
-        APISettings(
-            {"ISSUER_VALIDATION": "invalid"},
-            DEFAULTS,
-            IMPORT_STRINGS,
-        )
-
-
-@pytest.mark.parametrize("value", ["issuer", ["issuer", ""], ["issuer", 1]])
-def test_allowed_issuers_must_contain_non_empty_strings(value):
-    with pytest.raises(RuntimeError, match="ALLOWED_ISSUERS"):
+@pytest.mark.parametrize(
+    "value",
+    ["", " ", 1, [], ["issuer", ""], ["issuer", 1]],
+)
+def test_issuer_must_be_non_empty_string_or_string_sequence(value):
+    with pytest.raises(RuntimeError, match="ISSUER"):
         APISettings(
             {
-                "ISSUER_VALIDATION": "dynamic",
-                "ALLOWED_ISSUERS": value,
+                "ISSUER": value,
             },
             DEFAULTS,
             IMPORT_STRINGS,
         )
 
 
-def test_allowed_issuers_requires_dynamic_issuer_validation():
-    with pytest.raises(RuntimeError, match="ISSUER_VALIDATION"):
-        APISettings(
-            {
-                "ISSUER_VALIDATION": "static",
-                "ALLOWED_ISSUERS": ["https://issuer.example"],
-            },
-            DEFAULTS,
-            IMPORT_STRINGS,
-        )
-
-
-def test_dynamic_issuer_validation_rejects_static_issuer_and_allowed_issuers():
-    with pytest.raises(RuntimeError, match="ISSUER'.*ALLOWED_ISSUERS"):
-        APISettings(
-            {
-                "ISSUER_VALIDATION": "dynamic",
-                "ISSUER": "https://issuer.example",
-                "ALLOWED_ISSUERS": ["https://issuer.example"],
-            },
-            DEFAULTS,
-            IMPORT_STRINGS,
-        )
-
-
-def test_allowed_issuers_with_dynamic_validation_is_valid():
+def test_issuer_sequence_is_valid():
     settings = APISettings(
         {
-            "ISSUER_VALIDATION": "dynamic",
-            "ALLOWED_ISSUERS": ["https://issuer.example"],
+            "ISSUER": ["https://issuer.example"],
         },
         DEFAULTS,
         IMPORT_STRINGS,
     )
 
-    assert settings.ALLOWED_ISSUERS == ["https://issuer.example"]
+    assert settings.ISSUER == ["https://issuer.example"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,70 @@
+import pytest
+
+from rest_framework_simplejwt.settings import APISettings, DEFAULTS, IMPORT_STRINGS
+
+
+def test_validation_mode_must_be_supported():
+    with pytest.raises(RuntimeError, match="AUDIENCE_VALIDATION"):
+        APISettings(
+            {"AUDIENCE_VALIDATION": "invalid"},
+            DEFAULTS,
+            IMPORT_STRINGS,
+        )
+
+    with pytest.raises(RuntimeError, match="ISSUER_VALIDATION"):
+        APISettings(
+            {"ISSUER_VALIDATION": "invalid"},
+            DEFAULTS,
+            IMPORT_STRINGS,
+        )
+
+
+@pytest.mark.parametrize("value", ["issuer", ["issuer", ""], ["issuer", 1]])
+def test_allowed_issuers_must_contain_non_empty_strings(value):
+    with pytest.raises(RuntimeError, match="ALLOWED_ISSUERS"):
+        APISettings(
+            {
+                "ISSUER_VALIDATION": "dynamic",
+                "ALLOWED_ISSUERS": value,
+            },
+            DEFAULTS,
+            IMPORT_STRINGS,
+        )
+
+
+def test_allowed_issuers_requires_dynamic_issuer_validation():
+    with pytest.raises(RuntimeError, match="ISSUER_VALIDATION"):
+        APISettings(
+            {
+                "ISSUER_VALIDATION": "static",
+                "ALLOWED_ISSUERS": ["https://issuer.example"],
+            },
+            DEFAULTS,
+            IMPORT_STRINGS,
+        )
+
+
+def test_dynamic_issuer_validation_rejects_static_issuer_and_allowed_issuers():
+    with pytest.raises(RuntimeError, match="ISSUER'.*ALLOWED_ISSUERS"):
+        APISettings(
+            {
+                "ISSUER_VALIDATION": "dynamic",
+                "ISSUER": "https://issuer.example",
+                "ALLOWED_ISSUERS": ["https://issuer.example"],
+            },
+            DEFAULTS,
+            IMPORT_STRINGS,
+        )
+
+
+def test_allowed_issuers_with_dynamic_validation_is_valid():
+    settings = APISettings(
+        {
+            "ISSUER_VALIDATION": "dynamic",
+            "ALLOWED_ISSUERS": ["https://issuer.example"],
+        },
+        DEFAULTS,
+        IMPORT_STRINGS,
+    )
+
+    assert settings.ALLOWED_ISSUERS == ["https://issuer.example"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,7 @@ def test_validation_mode_must_be_supported():
             IMPORT_STRINGS,
         )
 
+
 @pytest.mark.parametrize(
     "value",
     ["", " ", 1, [], ["issuer", ""], ["issuer", 1]],

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rest_framework_simplejwt.settings import APISettings, DEFAULTS, IMPORT_STRINGS
+from rest_framework_simplejwt.settings import DEFAULTS, IMPORT_STRINGS, APISettings
 
 
 def test_validation_mode_must_be_supported():

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -309,6 +309,32 @@ class TestToken(TestCase):
         with self.assertRaises(TokenError):
             token.verify_iss()
 
+    @override_api_settings(
+        ISSUER=("https://issuer-1.domain.tld", "https://issuer-2.domain.tld")
+    )
+    def test_set_iss_does_not_default_to_issuer_sequence(self):
+        token = MyToken()
+        self.assertNotIn("iss", token)
+
+    @override_api_settings(
+        ISSUER=("https://issuer-1.domain.tld", "https://issuer-2.domain.tld")
+    )
+    def test_verify_iss_accepts_issuer_sequence(self):
+        token = MyToken()
+        token["iss"] = "https://issuer-2.domain.tld"
+
+        token.verify_iss()
+
+    @override_api_settings(
+        ISSUER=("https://issuer-1.domain.tld", "https://issuer-2.domain.tld")
+    )
+    def test_verify_iss_rejects_mismatch_against_issuer_sequence(self):
+        token = MyToken()
+        token["iss"] = "https://other.domain.tld"
+
+        with self.assertRaises(TokenError):
+            token.verify_iss()
+
     @override_api_settings(AUDIENCE="my-audience")
     def test_set_aud_defaults_to_configured_audience(self):
         token = MyToken()


### PR DESCRIPTION

This pull request introduces enhanced support for dynamic and static validation of JWT audience and issuer claims in Simple JWT, along with improved settings validation and more flexible claim handling. It adds new settings (`AUDIENCE_VALIDATION`, `ISSUER_CLAIM`), refines how audience and issuer are validated or set, and provides comprehensive documentation and tests for these behaviors.

**Settings and Validation Improvements:**

* Added the `AUDIENCE_VALIDATION` setting to control whether audience validation is "static" (default, enforced by PyJWT) or "dynamic" (enforced by Simple JWT logic after decoding). [[1]](diffhunk://#diff-d82241772fb86e472d94c9a04ee0802ed1d4cf03c9e688c0bbc723d78dceb077R23-R25) [[2]](diffhunk://#diff-1d78ba60e1efa4b7b08982e1bbaeceffefea079d402b7d58e57c0cfc7e6c78d8R27-R29) [[3]](diffhunk://#diff-1d78ba60e1efa4b7b08982e1bbaeceffefea079d402b7d58e57c0cfc7e6c78d8R160-R222)
* Added the `ISSUER_CLAIM` setting to allow customization of the issuer claim name (default: `"iss"`). [[1]](diffhunk://#diff-d82241772fb86e472d94c9a04ee0802ed1d4cf03c9e688c0bbc723d78dceb077R23-R25) [[2]](diffhunk://#diff-1d78ba60e1efa4b7b08982e1bbaeceffefea079d402b7d58e57c0cfc7e6c78d8R27-R29) [[3]](diffhunk://#diff-1d78ba60e1efa4b7b08982e1bbaeceffefea079d402b7d58e57c0cfc7e6c78d8R160-R222)
* Improved validation of settings: now checks that `AUDIENCE_VALIDATION` is a supported value and that `ISSUER` is a non-empty string or a sequence of non-empty strings, raising clear errors otherwise. [[1]](diffhunk://#diff-d82241772fb86e472d94c9a04ee0802ed1d4cf03c9e688c0bbc723d78dceb077R70-R144) [[2]](diffhunk://#diff-f20069a79c955c52519f37001105df187ba738b9a4dd49af010c723ff810200cR1-R39)

**Token Claim Handling:**

* Added methods to the `Token` class for setting and verifying audience (`aud`) and issuer (`iss`) claims, supporting both static and dynamic configurations, and handling both single and multiple allowed issuers/audiences. [[1]](diffhunk://#diff-e9863905dc4ef26b6bf2d8b6dc126dbb0e8ee574571c0c905af50933db5c1856R134-R139) [[2]](diffhunk://#diff-e9863905dc4ef26b6bf2d8b6dc126dbb0e8ee574571c0c905af50933db5c1856R152-R286) [[3]](diffhunk://#diff-e9863905dc4ef26b6bf2d8b6dc126dbb0e8ee574571c0c905af50933db5c1856R83-R84)
* Updated token creation and validation flows to ensure `iss` and `aud` claims are set and checked according to the new settings and logic. [[1]](diffhunk://#diff-e9863905dc4ef26b6bf2d8b6dc126dbb0e8ee574571c0c905af50933db5c1856R83-R84) [[2]](diffhunk://#diff-5192d507094cc6c3c4bbdc4280b4b25cd5d0db411335e208ad953d3511ecb59dR171)

**Backend and Decode Logic:**

* Updated the backend to allow skipping audience/issuer validation at the PyJWT decode step, deferring to Simple JWT logic when in dynamic mode or when multiple issuers are configured. [[1]](diffhunk://#diff-5789acf92aeca2ced1d02a664f5b7c4ca1db95e2269d0d4800167b79afe72d99R51-R52) [[2]](diffhunk://#diff-5789acf92aeca2ced1d02a664f5b7c4ca1db95e2269d0d4800167b79afe72d99R62-R69) [[3]](diffhunk://#diff-5789acf92aeca2ced1d02a664f5b7c4ca1db95e2269d0d4800167b79afe72d99L168-R180) [[4]](diffhunk://#diff-5fe5d26efdce206b257cb0c7c4568776b48bad5649082b83bb666af8bcb2022dL8-R9)

**Documentation and Testing:**

* Expanded documentation to explain the new settings and behaviors, including usage examples for dynamic audiences and issuers.
* Added and updated tests to cover the new settings validation, claim handling, and backend decode logic. [[1]](diffhunk://#diff-f20069a79c955c52519f37001105df187ba738b9a4dd49af010c723ff810200cR1-R39) [[2]](diffhunk://#diff-51d1cbb326cf0b05cde57945719d3b9c1f69f7d3f897ff247d19e0a0de7a3a38R299-R365) [[3]](diffhunk://#diff-09e1c5342323ae293ce8c6ee45eed0bfd1bf01a755d4d82dedbe9651e3a7f979R373-R411)

These changes make Simple JWT more flexible for multi-tenant or dynamic audience/issuer scenarios, and ensure that misconfigurations are detected early with clear error messages.