### PR TITLE
Add importlib to doc dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ extras_require = {
     "doc": [
         "Sphinx",
         "sphinx_rtd_theme>=0.1.9",
+        "importlib",
     ],
     "dev": [
         "pytest-watch",


### PR DESCRIPTION
Was not added in this PR: https://github.com/jazzband/djangorestframework-simplejwt/pull/959/

See build error https://app.readthedocs.org/projects/django-rest-framework-simplejwt/builds/31339402/