### PR TITLE
chore: bump python-jose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         "ipython",
     ],
     "python-jose": [
-        "python-jose==3.3.0",
+        "python-jose==3.5.0",
     ],
     "crypto": [
         "cryptography>=3.3.1",


### PR DESCRIPTION
Motivated by:
Fix for CVE-2024-33664 - JWE limited to 250KiB
Fix for CVE-2024-33663 - signing JWT with public key is now forbidden