### PR TITLE
Standardize password hashing and introduce configurable hashing for token revocation

### DIFF
--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -10,7 +10,7 @@ from .exceptions import AuthenticationFailed, InvalidToken, TokenError
 from .models import TokenUser
 from .settings import api_settings
 from .tokens import Token
-from .utils import get_md5_hash_password
+from .utils import get_password_hash
 
 AUTH_HEADER_TYPES = api_settings.AUTH_HEADER_TYPES
 
@@ -145,7 +145,10 @@ class JWTAuthentication(authentication.BaseAuthentication):
         if api_settings.CHECK_REVOKE_TOKEN:
             if validated_token.get(
                 api_settings.REVOKE_TOKEN_CLAIM
-            ) != get_md5_hash_password(user.password):
+            ) != get_password_hash(
+                user.password,
+                algorithm=api_settings.CHECK_REVOKE_TOKEN_HASH_ALGORITHM,
+            ):
                 raise AuthenticationFailed(
                     self.default_error_messages["password_changed"],
                     code="password_changed",

--- a/rest_framework_simplejwt/serializers.py
+++ b/rest_framework_simplejwt/serializers.py
@@ -11,7 +11,7 @@ from rest_framework.request import Request
 from .models import TokenUser
 from .settings import api_settings
 from .tokens import RefreshToken, SlidingToken, Token, UntypedToken
-from .utils import get_md5_hash_password
+from .utils import get_password_hash
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
@@ -137,7 +137,10 @@ class TokenRefreshSerializer(serializers.Serializer):
             if api_settings.CHECK_REVOKE_TOKEN:
                 if refresh.payload.get(
                     api_settings.REVOKE_TOKEN_CLAIM
-                ) != get_md5_hash_password(user.password):
+                ) != get_password_hash(
+                    user.password,
+                    algorithm=api_settings.CHECK_REVOKE_TOKEN_HASH_ALGORITHM,
+                ):
                     # If the password has changed, we blacklist the token
                     # to prevent any further use.
                     if (
@@ -206,7 +209,10 @@ class TokenRefreshSlidingSerializer(serializers.Serializer):
             if api_settings.CHECK_REVOKE_TOKEN:
                 if token.payload.get(
                     api_settings.REVOKE_TOKEN_CLAIM
-                ) != get_md5_hash_password(user.password):
+                ) != get_password_hash(
+                    user.password,
+                    algorithm=api_settings.CHECK_REVOKE_TOKEN_HASH_ALGORITHM,
+                ):
                     # If the password has changed, we blacklist the token
                     # to prevent any further use.
                     if (

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -46,6 +46,7 @@ DEFAULTS = {
     "SLIDING_TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSlidingSerializer",
     "CHECK_REVOKE_TOKEN": False,
     "REVOKE_TOKEN_CLAIM": "hash_password",
+    "CHECK_REVOKE_TOKEN_HASH_ALGORITHM": "md5",
     "CHECK_USER_IS_ACTIVE": True,
 }
 

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -22,7 +22,7 @@ from .utils import (
     datetime_from_epoch,
     datetime_to_epoch,
     format_lazy,
-    get_md5_hash_password,
+    get_password_hash,
     logger,
 )
 
@@ -231,8 +231,8 @@ class Token:
         token[api_settings.USER_ID_CLAIM] = user_id
 
         if api_settings.CHECK_REVOKE_TOKEN:
-            token[api_settings.REVOKE_TOKEN_CLAIM] = get_md5_hash_password(
-                user.password
+            token[api_settings.REVOKE_TOKEN_CLAIM] = get_password_hash(
+                user.password, algorithm=api_settings.CHECK_REVOKE_TOKEN_HASH_ALGORITHM
             )
 
         return token

--- a/rest_framework_simplejwt/utils.py
+++ b/rest_framework_simplejwt/utils.py
@@ -8,11 +8,28 @@ from django.conf import settings
 from django.utils.functional import lazy
 
 
+def get_password_hash(password: str, algorithm: str = "md5") -> str:
+    """
+    Returns hash of the given password using specified algorithm.
+    Defaults to MD5 for backward compatibility.
+    """
+    try:
+        hash_obj = hashlib.new(algorithm)
+    except ValueError:
+        logger.warning(
+            f"Hashing algorithm '{algorithm}' not supported by hashlib. Falling back to MD5."
+        )
+        hash_obj = hashlib.md5()
+
+    hash_obj.update(password.encode())
+    return hash_obj.hexdigest().upper()
+
+
 def get_md5_hash_password(password: str) -> str:
     """
-    Returns MD5 hash of the given password
+    Legacy wrapper for MD5 hashing.
     """
-    return hashlib.md5(password.encode()).hexdigest().upper()
+    return get_password_hash(password, algorithm="md5")
 
 
 def make_utc(dt: datetime) -> datetime:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -10,7 +10,7 @@ from rest_framework_simplejwt.exceptions import AuthenticationFailed, InvalidTok
 from rest_framework_simplejwt.models import TokenUser
 from rest_framework_simplejwt.settings import api_settings
 from rest_framework_simplejwt.tokens import AccessToken, SlidingToken
-from rest_framework_simplejwt.utils import get_md5_hash_password
+from rest_framework_simplejwt.utils import get_password_hash
 
 from .utils import override_api_settings
 
@@ -220,7 +220,9 @@ class TestJWTAuthentication(TestCase):
             self.backend.get_user(payload)
 
         if api_settings.CHECK_REVOKE_TOKEN:
-            payload[api_settings.REVOKE_TOKEN_CLAIM] = get_md5_hash_password(u.password)
+            payload[api_settings.REVOKE_TOKEN_CLAIM] = get_password_hash(
+                u.password, algorithm=api_settings.CHECK_REVOKE_TOKEN_HASH_ALGORITHM
+            )
 
         # Otherwise, should return correct user
         self.assertEqual(self.backend.get_user(payload).id, u.id)


### PR DESCRIPTION
Hardcoded MD5 hashing for password comparisons in `REVOKE_TOKEN_CLAIM` has been replaced with a more flexible mechanism. This update introduces a new setting, `CHECK_REVOKE_TOKEN_HASH_ALGORITHM`, which defaults to `md5` to maintain strict backward compatibility for existing tokens. Users can now choose more modern algorithms like `sha256` or `sha512` by updating their project settings.

Refactoring the internal hashing utility to support multiple algorithms ensures that authentication and token validation remain robust while providing a clear path for modernization. The change impact is localized to:
- `settings.py`: Added default hash configuration.
- `utils.py`: Enhanced hashing utility with support for dynamic algorithms.
- `tokens.py`, `serializers.py`, `authentication.py`: Integrated the configurable hashing logic into core workflows.

Existing tests in `tests/test_authentication.py` have been updated to reflect these changes, ensuring that the revocation check logic continues to function as expected under the new configurable model. This approach avoids breaking current installations while significantly improving the project's extensibility for different hashing standards.