### PR TITLE
feat(auth): support multiple cookie names for CookieJWTAuthentication

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -149,3 +149,31 @@ refresh token to obtain another access token:
 
   ...
   {"access":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX3BrIjoxLCJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiY29sZF9zdHVmZiI6IuKYgyIsImV4cCI6MTIzNTY3LCJqdGkiOiJjNzE4ZTVkNjgzZWQ0NTQyYTU0NWJkM2VmMGI0ZGQ0ZSJ9.ekxRxgb9OKmHkfy-zs1Ro_xs1eMLXiR17dIDBVxeT-w"}
+
+
+CookieJWTAuthentication
+-----------------------
+
+``CookieJWTAuthentication`` is an alternative authentication class that retrieves
+the JWT from cookies instead of the ``Authorization`` header.
+
+If multiple cookie names are configured, the first cookie containing a non-empty
+value is used as the token source.
+
+Example usage:
+
+.. code-block:: python
+
+    SIMPLE_JWT = {
+        "COOKIE_NAME": ["access_token", "simple_jwt"],
+    }
+
+    REST_FRAMEWORK = {
+        "DEFAULT_AUTHENTICATION_CLASSES": (
+            "rest_framework_simplejwt.authentication.CookieJWTAuthentication",
+        )
+    }
+
+When using cookie-based authentication, ensure that appropriate CSRF protections
+and secure cookie settings such as ``HttpOnly``, ``Secure``, and ``SameSite``
+are configured for your application.

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -189,8 +189,6 @@ def default_user_authentication_rule(user: AuthUser | None) -> bool:
     )
 
 
-
-
 class CookieJWTAuthentication(JWTAuthentication):
     """
     Authenticate users using a JWT stored in one of the configured cookies.
@@ -205,7 +203,7 @@ class CookieJWTAuthentication(JWTAuthentication):
             return [cookie_names]
         return list(cookie_names)
 
-    def get_raw_token_from_cookies(self, request) -> Optional[str]:
+    def get_raw_token_from_cookies(self, request) -> str | None:
         """
         Return the first token found in the configured cookies.
         """

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -187,3 +187,41 @@ def default_user_authentication_rule(user: AuthUser | None) -> bool:
     return user is not None and (
         not api_settings.CHECK_USER_IS_ACTIVE or user.is_active
     )
+
+
+
+
+class CookieJWTAuthentication(JWTAuthentication):
+    """
+    Authenticate users using a JWT stored in one of the configured cookies.
+
+    If multiple cookie names are configured, the first cookie that contains
+    a non-empty value is used as the raw token. Only that token is validated.
+    """
+
+    def get_cookie_names(self):
+        cookie_names = api_settings.COOKIE_NAME
+        if isinstance(cookie_names, str):
+            return [cookie_names]
+        return list(cookie_names)
+
+    def get_raw_token_from_cookies(self, request) -> Optional[str]:
+        """
+        Return the first token found in the configured cookies.
+        """
+        for cookie_name in self.get_cookie_names():
+            token = request.COOKIES.get(cookie_name)
+            if token:
+                return token
+        return None
+
+    def authenticate(self, request):
+        """
+        Validate a token retrieved from cookies.
+        """
+        raw_token = self.get_raw_token_from_cookies(request)
+        if raw_token is None:
+            return None
+
+        validated_token = self.get_validated_token(raw_token)
+        return self.get_user(validated_token), validated_token

--- a/rest_framework_simplejwt/settings.py
+++ b/rest_framework_simplejwt/settings.py
@@ -47,6 +47,7 @@ DEFAULTS = {
     "CHECK_REVOKE_TOKEN": False,
     "REVOKE_TOKEN_CLAIM": "hash_password",
     "CHECK_USER_IS_ACTIVE": True,
+    "COOKIE_NAME": [],
 }
 
 IMPORT_STRINGS = (

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -277,3 +277,152 @@ class TestJWTStatelessUserAuthentication(TestCase):
 
         # Restore default TokenUser for future tests
         api_settings.TOKEN_USER_CLASS = temp
+
+
+
+
+
+
+
+
+class TestCookieJWTAuthentication(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.backend = authentication.CookieJWTAuthentication()
+
+    @override_api_settings(COOKIE_NAME="access")
+    def test_get_cookie_names_single_string(self):
+        # When COOKIE_NAME is a string, get_cookie_names should return a list of length 1
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        self.assertEqual(backend.get_cookie_names(), ["access"])
+
+    @override_api_settings(COOKIE_NAME=["access", "jwt"])
+    def test_get_cookie_names_list(self):
+        # When COOKIE_NAME is an iterable, get_cookie_names should return a list with same items
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        self.assertEqual(backend.get_cookie_names(), ["access", "jwt"])
+
+    @override_api_settings(COOKIE_NAME="access")
+    def test_get_raw_token_from_cookies_no_cookie(self):
+        # Should return None if no configured cookie is present
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        request = self.factory.get("/test-url/")
+        self.assertIsNone(backend.get_raw_token_from_cookies(request))
+
+    @override_api_settings(COOKIE_NAME="access")
+    def test_get_raw_token_from_cookies_single_cookie(self):
+        # Should return the value of the configured cookie if present
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        token = "test-token"
+        request = self.factory.get("/test-url/")
+        request.COOKIES["access"] = token
+
+        self.assertEqual(backend.get_raw_token_from_cookies(request), token)
+
+    @override_api_settings(COOKIE_NAME=["access", "jwt"])
+    def test_get_raw_token_from_cookies_multiple_cookies_first_non_empty(self):
+        # Should return the first non-empty token based on COOKIE_NAME order
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        request = self.factory.get("/test-url/")
+        # First cookie is empty, second has token
+        request.COOKIES["access"] = ""
+        request.COOKIES["jwt"] = "real-token"
+
+        self.assertEqual(
+            backend.get_raw_token_from_cookies(request),
+            "real-token",
+        )
+
+    @override_api_settings(COOKIE_NAME=["access", "jwt"])
+    def test_get_raw_token_from_cookies_ignores_unconfigured_cookies(self):
+        # Should not read cookies that are not in COOKIE_NAME
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        request = self.factory.get("/test-url/")
+        request.COOKIES["other"] = "other-token"
+
+        self.assertIsNone(backend.get_raw_token_from_cookies(request))
+
+    @override_api_settings(COOKIE_NAME="access")
+    def test_authenticate_returns_none_when_no_cookie(self):
+        # authenticate should return None when no configured cookie is present
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+        request = self.factory.get("/test-url/")
+
+        self.assertIsNone(backend.authenticate(request))
+
+    @override_api_settings(COOKIE_NAME="access")
+    def test_authenticate_with_valid_token_in_cookie(self):
+        # Should authenticate and return (user, validated_token) when cookie contains a valid token
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+
+        user = User.objects.create_user(username="cookieuser")
+        access_token = AccessToken.for_user(user)
+
+        request = self.factory.get("/test-url/")
+        request.COOKIES["access"] = str(access_token)
+
+        user_obj, validated_token = backend.authenticate(request)
+
+        self.assertEqual(user_obj.id, user.id)
+        self.assertEqual(validated_token.payload, access_token.payload)
+
+    @override_api_settings(COOKIE_NAME="access")
+    def test_authenticate_with_invalid_token_in_cookie(self):
+        # Should raise InvalidToken if cookie contains an invalid token
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+
+        request = self.factory.get("/test-url/")
+        request.COOKIES["access"] = "not-a-real-token"
+
+        with self.assertRaises(InvalidToken):
+            backend.authenticate(request)
+
+    @override_api_settings(COOKIE_NAME=["access", "jwt"])
+    def test_authenticate_uses_first_non_empty_cookie(self):
+        # When multiple cookie names are configured, authenticate should use
+        # the first non-empty one and ignore the others
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+
+        primary_user = User.objects.create_user(username="primary")
+        secondary_user = User.objects.create_user(username="secondary")
+
+        primary_token = AccessToken.for_user(primary_user)
+        secondary_token = AccessToken.for_user(secondary_user)
+
+        request = self.factory.get("/test-url/")
+        # Order: ["access", "jwt"]
+        request.COOKIES["access"] = str(primary_token)
+        request.COOKIES["jwt"] = str(secondary_token)
+
+        user_obj, validated_token = backend.authenticate(request)
+
+        self.assertEqual(user_obj.id, primary_user.id)
+        self.assertEqual(validated_token.payload, primary_token.payload)
+
+    @override_api_settings(COOKIE_NAME=["access", "jwt"])
+    def test_authenticate_skips_empty_first_cookie(self):
+        # If the first cookie is empty, it should fall back to the next one
+        reload(authentication)
+        backend = authentication.CookieJWTAuthentication()
+
+        user = User.objects.create_user(username="fallback")
+        token = AccessToken.for_user(user)
+
+        request = self.factory.get("/test-url/")
+        request.COOKIES["access"] = ""
+        request.COOKIES["jwt"] = str(token)
+
+        user_obj, validated_token = backend.authenticate(request)
+
+        self.assertEqual(user_obj.id, user.id)
+        self.assertEqual(validated_token.payload, token.payload)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -279,12 +279,6 @@ class TestJWTStatelessUserAuthentication(TestCase):
         api_settings.TOKEN_USER_CLASS = temp
 
 
-
-
-
-
-
-
 class TestCookieJWTAuthentication(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()


### PR DESCRIPTION
Add cookie-based token support for CookieJWTAuthentication

PR Description
This PR adds a small improvement to CookieJWTAuthentication to support retrieving JWT tokens from cookies.

Context
When using Django authentication together with set_cookie, it is common to store JWT tokens in cookies for security reasons (e.g., HttpOnly cookies). In many frontend applications, requests are sent with:
credentials: "include"


In this scenario, the browser automatically sends cookies with the request, but the token is not placed in the Authorization header.

Problem
Currently, SimpleJWT primarily expects tokens to be provided in the Authorization header. When authentication tokens are stored in cookies, the backend cannot authenticate the user unless the frontend manually copies the token into the header.

This creates friction between:

standard cookie-based authentication flows
frontend applications using credentials: "include"
Solution
This change introduces a small extension that allows CookieJWTAuthentication to retrieve the token directly from configured cookies.

The authentication backend simply:

checks the configured cookie names
retrieves the first non-empty cookie value
validates it as a JWT token
This allows applications storing JWT tokens in cookies to authenticate users without requiring the token to be manually copied into request headers.

Backward Compatibility
This change is fully backward compatible:

Existing header-based authentication remains unchanged.
The new logic only applies when CookieJWTAuthentication is used.
No existing behavior is modified.
Motivation
This small change helps align SimpleJWT with common frontend patterns where:

tokens are stored using set_cookie
requests are sent with credentials: "include"
authentication relies on cookies instead of headers
Although the change is minimal, it enables a more seamless integration between Django backends and modern frontend applications.