### PR TITLE
fix: case-insensitive Authorization scheme matching per RFC 7235 §2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   - Follows RFC 7235, where authentication failures should return 401.
   - Clearer for clients: signals an auth issue instead of suggesting the endpoint is missing.
 
+### Fixed
+- `JWTAuthentication.get_raw_token()` now matches the `Authorization` scheme prefix case-insensitively, per RFC 7235 §2.1. The module-level `AUTH_HEADER_TYPE_BYTES` constant is unchanged for back-compat. Closes #908.
+
 
 ## 5.5.1
 

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -22,9 +22,7 @@ AUTH_HEADER_TYPE_BYTES: set[bytes] = {
 }
 
 # Pre-lowered for case-insensitive scheme matching per RFC 7235 §2.1.
-_AUTH_HEADER_TYPE_BYTES_LOWER: set[bytes] = {
-    h.lower() for h in AUTH_HEADER_TYPE_BYTES
-}
+_AUTH_HEADER_TYPE_BYTES_LOWER: set[bytes] = {h.lower() for h in AUTH_HEADER_TYPE_BYTES}
 
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 

--- a/rest_framework_simplejwt/authentication.py
+++ b/rest_framework_simplejwt/authentication.py
@@ -21,6 +21,11 @@ AUTH_HEADER_TYPE_BYTES: set[bytes] = {
     h.encode(HTTP_HEADER_ENCODING) for h in AUTH_HEADER_TYPES
 }
 
+# Pre-lowered for case-insensitive scheme matching per RFC 7235 §2.1.
+_AUTH_HEADER_TYPE_BYTES_LOWER: set[bytes] = {
+    h.lower() for h in AUTH_HEADER_TYPE_BYTES
+}
+
 AuthUser = TypeVar("AuthUser", AbstractBaseUser, TokenUser)
 
 
@@ -84,7 +89,7 @@ class JWTAuthentication(authentication.BaseAuthentication):
             # Empty AUTHORIZATION header sent
             return None
 
-        if parts[0] not in AUTH_HEADER_TYPE_BYTES:
+        if parts[0].lower() not in _AUTH_HEADER_TYPE_BYTES_LOWER:
             # Assume the header does not contain a JSON web token
             return None
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -85,6 +85,14 @@ class TestJWTAuthentication(TestCase):
             self.fake_token,
         )
 
+    def test_get_raw_token_scheme_is_case_insensitive(self):
+        # Per RFC 7235 §2.1, scheme matching is case-insensitive.
+        reload(authentication)
+
+        for prefix in (b"bearer", b"BEARER", b"bEaReR"):
+            header = prefix + b" " + self.fake_token
+            self.assertEqual(self.backend.get_raw_token(header), self.fake_token)
+
     def test_get_validated_token(self):
         # Should raise InvalidToken if token not valid
         token = AuthToken()


### PR DESCRIPTION
Picking up where #909 left off. The original PR (thanks @gumm for the legwork) was self-closed citing RFC 6750 §2.1 as requiring case-sensitivity, but a closer look at the ABNF suggests otherwise.

The RFC defines Bearer credentials as:

    credentials = "Bearer" 1*SP b64token

ABNF string literals are case-insensitive by default. To make `"Bearer"` case-sensitive, you'd need to write `%s"Bearer"`. The RFC doesn't, so the literal is case-insensitive. The broader HTTP authentication framework also calls out that "the scheme name is case-insensitive", so both specs agree.

In current `get_raw_token`, the byte-set membership check is strict, so `Authorization: bearer <token>` quietly returns `None` and the request 401s. Per spec, it should authenticate.

The fix is tiny: pre-compute a lowered variant of `AUTH_HEADER_TYPE_BYTES` once at module load, compare `parts[0].lower()` against it. `AUTH_HEADER_TYPE_BYTES` itself is unchanged, so anyone importing it externally sees no diff. Hopefully a quick review, hope it's useful. Let me know if you have questions or would like any changes!

Closes #908.