### PR TITLE
Use UUIDv7 for JTI claim on Python 3.13+

### DIFF
--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
-from uuid import uuid4
+try:
+    from uuid import uuid7 as _uuid_for_jti  # Python 3.13+
+except ImportError:
+    from uuid import uuid4 as _uuid_for_jti  # type: ignore[assignment]
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -150,7 +153,7 @@ class Token:
         See here:
         https://tools.ietf.org/html/rfc7519#section-4.1.7
         """
-        self.payload[api_settings.JTI_CLAIM] = uuid4().hex
+        self.payload[api_settings.JTI_CLAIM] = _uuid_for_jti().hex
 
     def set_exp(
         self,

--- a/rest_framework_simplejwt/tokens.py
+++ b/rest_framework_simplejwt/tokens.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
+
 try:
     from uuid import uuid7 as _uuid_for_jti  # Python 3.13+
 except ImportError:

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -250,6 +250,8 @@ class TestToken(TestCase):
 
         self.assertIn("jti", token)
         self.assertNotEqual(old_jti, token["jti"])
+        # JTI should be a 32-character hex string (UUID without hyphens)
+        self.assertRegex(token["jti"], r"^[0-9a-f]{32}$")
 
     @override_api_settings(JTI_CLAIM=None)
     def test_optional_jti(self):


### PR DESCRIPTION
Closes #943

## What

Replace `uuid4` with `uuid7` for JTI generation on Python 3.13+, falling back to `uuid4` on older versions.

```python
try:
    from uuid import uuid7 as _uuid_for_jti  # Python 3.13+
except ImportError:
    from uuid import uuid4 as _uuid_for_jti
```

## Why

UUIDv7 is time-ordered (monotonically increasing), which makes it significantly more efficient as a b-tree index key in the `OutstandingToken` table used for blacklisting. UUIDv4's random distribution causes index fragmentation and write amplification at scale; UUIDv7 inserts append near the end of the index, reducing page splits.

Python 3.13 added `uuid.uuid7()` to the standard library ([PEP 769](https://peps.python.org/pep-0769/)). Older supported versions (3.10–3.12) fall back to `uuid4`, preserving existing behavior.

## Changes

- `rest_framework_simplejwt/tokens.py`: conditional import; `set_jti()` uses `_uuid_for_jti().hex`
- `tests/test_tokens.py`: added format assertion (32-char hex string) to `test_set_jti`

No migration needed — the JTI column type and length are unchanged (hex string, 32 chars).